### PR TITLE
Bug 2025767: Prevent Machine from being considered provisioned until it exists in AWS

### DIFF
--- a/pkg/actuators/machine/controller_test.go
+++ b/pkg/actuators/machine/controller_test.go
@@ -1,0 +1,182 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	awsclient "github.com/openshift/machine-api-provider-aws/pkg/client"
+	mockaws "github.com/openshift/machine-api-provider-aws/pkg/client/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestMachineControllerWithDelayedExistSuccess(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	mockCtrl := gomock.NewController(t)
+	mockAWSClient := mockaws.NewMockClient(mockCtrl)
+	awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+		return mockAWSClient, nil
+	}
+
+	{ // Initialise Mock AWS responses for client
+		log.Printf("Initialising mock AWS responses")
+
+		// DesrcibeInstances by tags should only happen before the instance is created/if the provider ID returns nothing
+		// For the purpose of this test, don't provide an output, we want to control the provider ID response instead.
+		mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInputFromName()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
+
+		// Once the actuator has determined the Machine doesn't exist, it should eventually request to create the machine
+		mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", stubInstanceID, "192.168.0.10"), nil).Times(1)
+
+		// After the create, it will reconcile load balancer attachements, we don't care about these for this test
+		mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(stubDescribeTargetHealthOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
+		mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
+
+		// After create, we will assert that the instance doesn't exist for the first 3 times that the call is made
+		// - The first call is Exists, which will return that the instance does not exist
+		// - The second is in Create, check for possible eventual consistency errors. This will fail and then the
+		//   check for the providerStatus.InstanceID should prevent a second create and requeue.
+		// - The third call is Exists on the second reconcile, after which we start returning the instance to allow
+		//   the Create eventual consistency error to requeue again, after which Exists will succeed going forward.
+		assertNotExist := mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(stubInstanceID)).Return(&ec2.DescribeInstancesOutput{}, nil).MaxTimes(3)
+		mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(stubInstanceID)).Return(stubDescribeInstancesOutput("ami-a9acbbd6", stubInstanceID, ec2.InstanceStateNameRunning, "192.168.0.10"), nil).After(assertNotExist).AnyTimes()
+
+		// Once the machine gets to the update stage, tags will be updated
+		mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+	}
+
+	var k8sClient runtimeclient.Client
+	{ // Set up manager, actuator and controller
+		log.Printf("Initialising manager, actuator and controller")
+		mgr, err := manager.New(cfg, manager.Options{
+			Scheme:             scheme.Scheme,
+			MetricsBindAddress: "0",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		mgrCtx, cancel := context.WithCancel(context.Background())
+		go func() {
+			g.Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+		defer cancel()
+
+		k8sClient = mgr.GetClient()
+		eventRecorder := mgr.GetEventRecorderFor("awscontroller")
+
+		params := ActuatorParams{
+			Client:           k8sClient,
+			EventRecorder:    eventRecorder,
+			AwsClientBuilder: awsClientBuilder,
+		}
+		actuator := NewActuator(params)
+
+		g.Expect(machinecontroller.AddWithActuator(mgr, actuator)).To(Succeed())
+	}
+
+	var machine *machinev1.Machine
+	var machineKey runtimeclient.ObjectKey
+	{ // Init and create the machine and infrastructure object
+		log.Printf("Initialising and creating the Machine and supporting resources")
+		var err error
+		machine, err = stubMachine()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stubMachine).ToNot(BeNil())
+		machineKey = runtimeclient.ObjectKey{Namespace: machine.Namespace, Name: machine.Name}
+
+		// Create the machine
+		g.Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(ctx, machine)).To(Succeed())
+		}()
+
+		// Create infrastructure object
+		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: awsclient.GlobalInfrastuctureName}}
+		g.Expect(k8sClient.Create(ctx, infra)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(ctx, infra)).To(Succeed())
+		}()
+
+		// Create the credentials secret
+		awsCredentialsSecret := stubAwsCredentialsSecret()
+		g.Expect(k8sClient.Create(context.TODO(), awsCredentialsSecret)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(context.TODO(), awsCredentialsSecret)).To(Succeed())
+		}()
+
+		// Create the user data secret
+		userDataSecret := stubUserDataSecret()
+		g.Expect(k8sClient.Create(context.TODO(), userDataSecret)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(context.TODO(), userDataSecret)).To(Succeed())
+		}()
+
+		// Ensure the machine has synced to the cache
+		getMachine := func() error {
+			return k8sClient.Get(ctx, machineKey, machine)
+		}
+		g.Eventually(getMachine, timeout).Should(Succeed())
+	}
+
+	{
+		log.Printf("Check expectations of Machine after create")
+		// First thing the Machine controller does is move the machine to provisioning and requeue
+		waitForProvisioning := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			return machine.Status.Phase != nil && *machine.Status.Phase == "Provisioning", nil
+		}
+		g.Eventually(waitForProvisioning, timeout).Should(BeTrue(), "Machine was never moved to provisioning")
+
+		// Then we expect the controller to create the instance and set the instance ID
+		waitForInstanceID := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			if machine.Status.ProviderStatus == nil {
+				return false, errors.New("expected providerstatus to not be nil")
+			}
+			ps, err := ProviderStatusFromRawExtension(machine.Status.ProviderStatus)
+			if err != nil {
+				return false, err
+			}
+			return ps.InstanceID != nil && *ps.InstanceID == stubInstanceID, nil
+		}
+		g.Eventually(waitForInstanceID, timeout).Should(BeTrue(), "Instance ID was not set in provider status")
+		g.Expect(machine.Spec.ProviderID).To(BeNil(), "Provider ID should not be set after create")
+		g.Expect(machine.Status.Addresses).To(BeEmpty(), "Expected addresses to not be set after create")
+	}
+
+	{
+		log.Printf("Check expectations of Machine after update")
+		// First thing the Machine controller does is move the machine to provisioning and requeue
+		waitForProvisioned := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			return machine.Status.Phase != nil && *machine.Status.Phase == "Provisioned", nil
+		}
+		g.Eventually(waitForProvisioned, timeout).Should(BeTrue(), "Machine was never moved to provisioned")
+
+		g.Expect(machine.Spec.ProviderID).ToNot(BeNil())
+		g.Expect(*machine.Spec.ProviderID).To(ContainSubstring(stubInstanceID), "ProviderID should be set after update")
+		g.Expect(machine.Status.Addresses).To(HaveLen(4), "Expected addresses to be set after update")
+	}
+}

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -44,6 +44,7 @@ type machineScope struct {
 	// machine resource
 	machine            *machinev1.Machine
 	machineToBePatched runtimeclient.Patch
+	originalStatus     machinev1.MachineStatus
 	providerSpec       *machinev1.AWSMachineProviderConfig
 	providerStatus     *machinev1.AWSMachineProviderStatus
 }
@@ -75,6 +76,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		client:             params.client,
 		machine:            params.machine,
 		machineToBePatched: runtimeclient.MergeFrom(params.machine.DeepCopy()),
+		originalStatus:     params.machine.DeepCopy().Status,
 		providerSpec:       providerSpec,
 		providerStatus:     providerStatus,
 	}, nil
@@ -90,15 +92,25 @@ func (s *machineScope) patchMachine() error {
 	}
 	s.machine.Status.ProviderStatus = providerStatus
 
-	statusCopy := *s.machine.Status.DeepCopy()
-
-	// patch machine
-	if err := s.client.Patch(context.Background(), s.machine, s.machineToBePatched); err != nil {
-		klog.Errorf("Failed to patch machine %q: %v", s.machine.GetName(), err)
+	needsResourcePatch, err := s.needsResourcePatch()
+	if err != nil {
+		klog.Errorf("Failed to determine if machine patch required %q: %v", s.machine.GetName(), err)
 		return err
 	}
 
-	s.machine.Status = statusCopy
+	if needsResourcePatch {
+		// Copy the status so that it can be restored after the resource patch
+		statusCopy := *s.machine.Status.DeepCopy()
+
+		// patch machine
+		if err := s.client.Patch(context.Background(), s.machine, s.machineToBePatched); err != nil {
+			klog.Errorf("Failed to patch machine %q: %v", s.machine.GetName(), err)
+			return err
+		}
+
+		// The status was reset by the patch above, reset it before we patch the status
+		s.machine.Status = statusCopy
+	}
 
 	// patch status
 	if err := s.client.Status().Patch(context.Background(), s.machine, s.machineToBePatched); err != nil {
@@ -107,6 +119,19 @@ func (s *machineScope) patchMachine() error {
 	}
 
 	return nil
+}
+
+// needsResourcePatch is used to determine if the patch to the main resource would be a no-op
+func (s *machineScope) needsResourcePatch() (bool, error) {
+	machineCopy := s.machine.DeepCopy()
+	machineCopy.Status = s.originalStatus
+
+	data, err := s.machineToBePatched.Data(machineCopy)
+	if err != nil {
+		return false, fmt.Errorf("failed to calculate patch: %v", err)
+	}
+
+	return string(data) != "{}", nil
 }
 
 // getUserData fetches the user-data from the secret referenced in the Machine's

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -304,6 +304,12 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 	}
 }
 
+func stubDescribeInstancesInput(instanceID string) *ec2.DescribeInstancesInput {
+	return &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+}
+
 // StubDescribeDHCPOptions provides fake output
 func StubDescribeDHCPOptions() (*ec2.DescribeDhcpOptionsOutput, error) {
 	key := "key"

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -23,10 +23,11 @@ const (
 	awsCredentialsSecretName = "aws-credentials-secret"
 	userDataSecretName       = "aws-actuator-user-data-secret"
 
-	keyName        = "aws-actuator-key-name"
-	stubClusterID  = "aws-actuator-cluster"
-	stubAMIID      = "ami-a9acbbd6"
-	stubInstanceID = "i-02fcb933c5da7085c"
+	keyName         = "aws-actuator-key-name"
+	stubClusterID   = "aws-actuator-cluster"
+	stubMachineName = "aws-actuator-testing-machine"
+	stubAMIID       = "ami-a9acbbd6"
+	stubInstanceID  = "i-02fcb933c5da7085c"
 )
 
 const userDataBlob = `#cloud-config
@@ -107,7 +108,7 @@ func stubMachine() (*machinev1.Machine, error) {
 
 	machine := &machinev1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "aws-actuator-testing-machine",
+			Name:      stubMachineName,
 			Namespace: defaultNamespace,
 			Labels: map[string]string{
 				machinev1.MachineClusterIDLabel: stubClusterID,
@@ -296,7 +297,10 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 							Code: aws.Int64(16),
 						},
 						LaunchTime:       aws.Time(time.Now()),
+						PublicIpAddress:  aws.String(privateIP),
 						PrivateIpAddress: aws.String(privateIP),
+						PrivateDnsName:   aws.String("privateDNS"),
+						PublicDnsName:    aws.String("publicDNS"),
 					},
 				},
 			},
@@ -307,6 +311,18 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 func stubDescribeInstancesInput(instanceID string) *ec2.DescribeInstancesInput {
 	return &ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+}
+
+func stubDescribeInstancesInputFromName() *ec2.DescribeInstancesInput {
+	return &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsTagFilter("Name"),
+				Values: aws.StringSlice([]string{stubMachineName}),
+			},
+			clusterFilter(stubClusterID),
+		},
 	}
 }
 

--- a/pkg/actuators/machine/suite_test.go
+++ b/pkg/actuators/machine/suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -23,6 +24,7 @@ const (
 var (
 	k8sClient     client.Client
 	eventRecorder record.EventRecorder
+	cfg           *rest.Config
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +37,8 @@ func TestMain(m *testing.M) {
 
 	configv1.AddToScheme(scheme.Scheme)
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
We are seeing instances where AWS is not returning the instance we just created within a second or two of the initial creation time, returning a 400 error saying that the instance does not exist.
This makes the machine go into failed right now, and, in conjunction with an MHC, can lead to leaked machines as the instances are deleted before AWS acknowledges the existence of the Machine.

This PR is an attempt to improve this experience.
It does:
1. Do not set the addresses after create - this prevents the machine controller from saying the instance is provisioned, if exists does not return the instance, it will call create again
2. Before we create, we attempt exists again by looking for existing instances - if this succeeds, requeue and the next reconcile should work and call Update which corrects the status and provider ID
3. If the exists fails a second time at the beginning of the create, but an instance ID has been set on the status, requeue, we can't create another instance, that would cause a leak

The only flaw in this that I can currently think of is that if an instance is terminated before Exists ever succeeds, then we will requeue forever as Exists currently just silently ignores these kinds of errors. To improve this, Exists could return a "Instance was terminated" error which we can unwrap and handle specifically, though this would need to be handled in the core Machine controller, so needs further work.