### PR TITLE
CFE-68 : user defined resource tags on EC2 instances updatable

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -211,8 +211,8 @@ func (r *Reconciler) update() error {
 	runningLen := len(runningInstances)
 	var newestInstance *ec2.Instance
 
-	//Prepare the tag list with infrastructure tags.
-	//these tags will update to the ec2 instance.
+	// Prepare the tag list with infrastructure tags.
+	// These tags will be used to update the EC2 instance tags.
 	tagList, err := r.getTagsFromInfrastructure()
 	if err != nil {
 		return err
@@ -263,10 +263,10 @@ func (r *Reconciler) getTagsFromInfrastructure() (map[string]string, error) {
 	infraName := client.ObjectKey{Name: awsclient.GlobalInfrastuctureName}
 
 	if err := r.client.Get(r.Context, infraName, infra); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching Infrastructure %q: %v", infraName.Name, err)
 	}
 	tags := make(map[string]string)
-	ok, resourceTags := fetchInfraResourceTags(infra)
+	resourceTags, ok := fetchInfraResourceTags(infra)
 	if !ok {
 		return tags, nil
 	}

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -211,6 +211,13 @@ func (r *Reconciler) update() error {
 	runningLen := len(runningInstances)
 	var newestInstance *ec2.Instance
 
+	//Prepare the tag list with infrastructure tags.
+	//these tags will update to the ec2 instance.
+	tagList, err := r.getTagsFromInfrastructure()
+	if err != nil {
+		return err
+	}
+
 	if runningLen > 0 {
 		// It would be very unusual to have more than one here, but it is
 		// possible if someone manually provisions a machine with same tag name.
@@ -240,7 +247,7 @@ func (r *Reconciler) update() error {
 		return fmt.Errorf("failed to set machine cloud provider specifics: %w", err)
 	}
 
-	if err = correctExistingTags(r.machine, newestInstance, r.awsClient); err != nil {
+	if err = correctExistingTags(r.machine, newestInstance, r.awsClient, tagList); err != nil {
 		return fmt.Errorf("failed to correct existing instance tags: %w", err)
 	}
 
@@ -249,6 +256,25 @@ func (r *Reconciler) update() error {
 	r.machineScope.setProviderStatus(newestInstance, conditionSuccess())
 
 	return r.requeueIfInstancePending(newestInstance)
+}
+
+func (r *Reconciler) getTagsFromInfrastructure() (map[string]string, error) {
+	infra := &configv1.Infrastructure{}
+	infraName := client.ObjectKey{Name: awsclient.GlobalInfrastuctureName}
+
+	if err := r.client.Get(r.Context, infraName, infra); err != nil {
+		return nil, err
+	}
+	tags := make(map[string]string)
+	ok, resourceTags := fetchInfraResourceTags(infra)
+	if !ok {
+		return tags, nil
+	}
+
+	for _, value := range resourceTags {
+		tags[value.Key] = value.Value
+	}
+	return tags, nil
 }
 
 // exists returns true if machine exists.

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
@@ -134,7 +136,7 @@ func getInstanceByID(id string, client awsclient.Client, instanceStateFilter []*
 
 // correctExistingTags validates Name and clusterID tags are correct on the instance
 // and sets them if they are not.
-func correctExistingTags(machine *machinev1.Machine, instance *ec2.Instance, client awsclient.Client) error {
+func correctExistingTags(machine *machinev1.Machine, instance *ec2.Instance, client awsclient.Client, tags map[string]string) error {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.CreateTags
 	if instance == nil || instance.InstanceId == nil {
 		return fmt.Errorf("unexpected nil found in instance: %v", instance)
@@ -153,28 +155,41 @@ func correctExistingTags(machine *machinev1.Machine, instance *ec2.Instance, cli
 			if *tag.Key == "kubernetes.io/cluster/"+clusterID && *tag.Value == "owned" {
 				clusterTagOk = true
 			}
+			if tagValue, present := tags[*tag.Key]; present && *tag.Value == tagValue {
+				delete(tags, *tag.Key)
+			}
 		}
 	}
 
-	// Update our tags if they're not set or correct
+	tagsToAdd := []*ec2.Tag{}
+	for key, value := range tags {
+		tagsToAdd = append(tagsToAdd, &ec2.Tag{
+			Key:   aws.String(key),
+			Value: aws.String(value),
+		})
+	}
+
 	if !nameTagOk || !clusterTagOk {
+		tagsToAdd = append(tagsToAdd, &ec2.Tag{
+			Key:   aws.String("kubernetes.io/cluster/" + clusterID),
+			Value: aws.String("owned"),
+		})
+		tagsToAdd = append(tagsToAdd, &ec2.Tag{
+			Key:   aws.String("Name"),
+			Value: aws.String(machine.Name),
+		})
+	}
+
+	if len(tagsToAdd) != 0 {
 		// Create tags only adds/replaces what is present, does not affect other tags.
 		input := &ec2.CreateTagsInput{
 			Resources: []*string{
 				aws.String(*instance.InstanceId),
 			},
-			Tags: []*ec2.Tag{
-				{
-					Key:   aws.String("kubernetes.io/cluster/" + clusterID),
-					Value: aws.String("owned"),
-				},
-				{
-					Key:   aws.String("Name"),
-					Value: aws.String(machine.Name),
-				},
-			},
+			Tags: tagsToAdd,
 		}
-		klog.Infof("Invalid or missing instance tags for machine: %v; instanceID: %v, updating", machine.Name, *instance.InstanceId)
+		klog.Infof("updating Tags for machine: %v; instanceID: %v, tags: %+v",
+			machine.Name, *instance.InstanceId, tagsToAdd)
 		_, err := client.CreateTags(input)
 		return err
 	}
@@ -469,4 +484,13 @@ func ProviderStatusFromRawExtension(rawExtension *runtime.RawExtension) (*machin
 
 	klog.V(5).Infof("Got provider Status from raw extension: %+v", providerStatus)
 	return providerStatus, nil
+}
+
+func fetchInfraResourceTags(infra *configv1.Infrastructure) (bool, []configv1.AWSResourceTag) {
+	// TODO : https://github.com/openshift/api/pull/1064 , we should consider the spec over status if spec contains the user tags
+	if infra != nil && infra.Status.PlatformStatus != nil &&
+		infra.Status.PlatformStatus.AWS != nil && infra.Status.PlatformStatus.AWS.ResourceTags != nil {
+		return true, infra.Status.PlatformStatus.AWS.ResourceTags
+	}
+	return false, nil
 }

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -486,11 +486,11 @@ func ProviderStatusFromRawExtension(rawExtension *runtime.RawExtension) (*machin
 	return providerStatus, nil
 }
 
-func fetchInfraResourceTags(infra *configv1.Infrastructure) (bool, []configv1.AWSResourceTag) {
+func fetchInfraResourceTags(infra *configv1.Infrastructure) ([]configv1.AWSResourceTag, bool) {
 	// TODO : https://github.com/openshift/api/pull/1064 , we should consider the spec over status if spec contains the user tags
 	if infra != nil && infra.Status.PlatformStatus != nil &&
 		infra.Status.PlatformStatus.AWS != nil && infra.Status.PlatformStatus.AWS.ResourceTags != nil {
-		return true, infra.Status.PlatformStatus.AWS.ResourceTags
+		return infra.Status.PlatformStatus.AWS.ResourceTags, true
 	}
-	return false, nil
+	return nil, false
 }


### PR DESCRIPTION
**issue :**
Currently the user-defined tags during install are passed directly as parameters of the Machine and Machineset resources for the master and worker. As a result these tags cannot be updated by consulting the Infrastructure resource of the cluster where the user defined tags are written.

so intention of the changes is to update EC2 instance,
**Solution :** 
  The machine-api-provider-aws  update the EC2 instance tags from infrastructure resource on periodical bases.  when the resource tags are updated it should update the tags on the EC2 instances without restarts.

**target Release :** 4.11
