### PR TITLE
[OCPCLOUD-1384] Delete the placement group after machine removal 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	sigs.k8s.io/controller-tools v0.7.0
 )
 
+replace github.com/openshift/api => github.com/JoelSpeed/api v0.0.0-20220107173117-d1bbaa7a5511
+
 require (
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/JoelSpeed/api v0.0.0-20220107173117-d1bbaa7a5511 h1:VsWRlcMA7R5ttKiOMZs2ROozHhbhwXa5vDaIyGh8Zk0=
+github.com/JoelSpeed/api v0.0.0-20220107173117-d1bbaa7a5511/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -549,11 +551,6 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/openshift/api v0.0.0-20211209135129-c58d9f695577/go.mod h1:DoslCwtqUpr3d/gsbq4ZlkaMEdYqKxuypsDjorcHhME=
-github.com/openshift/api v0.0.0-20211215120111-7c47a5f63470/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
-github.com/openshift/api v0.0.0-20211217221424-8779abfbd571 h1:+ShYlGoPriGahTTFTjQ0RtNXW0srxDodk2STdc238Rk=
-github.com/openshift/api v0.0.0-20211217221424-8779abfbd571/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
-github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -373,7 +372,7 @@ func launchInstance(machine *machinev1.Machine, machineProviderConfig *machinev1
 		// https://docs.aws.amazon.com/sdk-for-go/api/aws/awserr/
 		if _, ok := err.(awserr.Error); ok {
 			if reqErr, ok := err.(awserr.RequestFailure); ok {
-				if strings.HasPrefix(strconv.Itoa(reqErr.StatusCode()), "4") {
+				if reqErr.StatusCode() >= 400 && reqErr.StatusCode() < 500 {
 					klog.Infof("Error launching instance: %v", reqErr)
 					return nil, mapierrors.InvalidMachineConfiguration("error launching instance: %v", reqErr.Message())
 				}
@@ -585,7 +584,7 @@ func checkOrCreatePlacementGroup(client awsclient.Client, placement machinev1.Pl
 func isAWS4xxError(err error) bool {
 	if _, ok := err.(awserr.Error); ok {
 		if reqErr, ok := err.(awserr.RequestFailure); ok {
-			if strings.HasPrefix(strconv.Itoa(reqErr.StatusCode()), "4") {
+			if reqErr.StatusCode() >= 400 && reqErr.StatusCode() < 500 {
 				return true
 			}
 		}

--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -886,6 +886,48 @@ func TestLaunchInstance(t *testing.T) {
 				UserData: aws.String(""),
 			},
 		},
+		{
+			name:            "With an Placement Group Name",
+			instancesOutput: stubReservation(stubAMIID, stubInstanceID, "192.168.0.10"),
+			providerConfig:  stubPlacementGroupNameConfig(),
+			succeeds:        true,
+			infra:           infra,
+			runInstancesInput: &ec2.RunInstancesInput{
+				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+					Name: aws.String(*providerConfig.IAMInstanceProfile.ID),
+				},
+				ImageId:      aws.String(*providerConfig.AMI.ID),
+				InstanceType: &providerConfig.InstanceType,
+				MinCount:     aws.Int64(1),
+				MaxCount:     aws.Int64(1),
+				KeyName:      providerConfig.KeyName,
+				TagSpecifications: []*ec2.TagSpecification{{
+					ResourceType: aws.String("instance"),
+					Tags:         stubTagListWithInfraObject,
+				}, {
+					ResourceType: aws.String("volume"),
+					Tags:         stubTagListWithInfraObject,
+				}},
+				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
+					{
+						DeviceIndex:              aws.Int64(providerConfig.DeviceIndex),
+						AssociatePublicIpAddress: providerConfig.PublicIP,
+						SubnetId:                 providerConfig.Subnet.ID,
+						Groups: []*string{
+							aws.String("sg-00868b02fbe29de17"),
+							aws.String("sg-0a4658991dc5eb40a"),
+							aws.String("sg-009a70e28fa4ba84e"),
+							aws.String("sg-07323d56fb932c84c"),
+							aws.String("sg-08b1ffd32874d59a2"),
+						},
+					},
+				},
+				Placement: &ec2.Placement{
+					GroupName: aws.String(stubPlacementGroupName),
+				},
+				UserData: aws.String(""),
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -402,9 +402,11 @@ func (r *Reconciler) deletePlacementGroup() error {
 	clusterID, _ := getClusterID(r.machine)
 	found := false
 	for _, tag := range placementGroup.Tags {
-		if tag.Key == aws.String("kubernetes.io/cluster/"+clusterID) && tag.Value == aws.String("owned") {
-			found = true
-			break
+		if tag.Key != nil && tag.Value != nil {
+			if aws.StringValue(tag.Key) == "kubernetes.io/cluster/"+clusterID && aws.StringValue(tag.Value) == "owned" {
+				found = true
+				break
+			}
 		}
 	}
 	if !found {

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -23,11 +23,12 @@ const (
 	awsCredentialsSecretName = "aws-credentials-secret"
 	userDataSecretName       = "aws-actuator-user-data-secret"
 
-	keyName         = "aws-actuator-key-name"
-	stubClusterID   = "aws-actuator-cluster"
-	stubMachineName = "aws-actuator-testing-machine"
-	stubAMIID       = "ami-a9acbbd6"
-	stubInstanceID  = "i-02fcb933c5da7085c"
+	keyName                = "aws-actuator-key-name"
+	stubClusterID          = "aws-actuator-cluster"
+	stubMachineName        = "aws-actuator-testing-machine"
+	stubAMIID              = "ami-a9acbbd6"
+	stubInstanceID         = "i-02fcb933c5da7085c"
+	stubPlacementGroupName = "placement-group-1"
 )
 
 const userDataBlob = `#cloud-config
@@ -230,6 +231,12 @@ func stubDedicatedInstanceTenancy() *machinev1.AWSMachineProviderConfig {
 func stubInvalidInstanceTenancy() *machinev1.AWSMachineProviderConfig {
 	pc := stubProviderConfig()
 	pc.Placement.Tenancy = "invalid"
+	return pc
+}
+
+func stubPlacementGroupNameConfig() *machinev1.AWSMachineProviderConfig {
+	pc := stubProviderConfig()
+	pc.Placement.GroupName = stubPlacementGroupName
 	return pc
 }
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -270,6 +270,30 @@ func stubDescribeTargetHealthOutput() *elbv2.DescribeTargetHealthOutput {
 	return &elbv2.DescribeTargetHealthOutput{}
 }
 
+func stubDescribePlacementGroupsInput(groupName string) *ec2.DescribePlacementGroupsInput {
+	return &ec2.DescribePlacementGroupsInput{
+		GroupNames: []*string{aws.String(groupName)},
+	}
+}
+
+func stubDescribePlacementGroupsOutput(groupName string) *ec2.DescribePlacementGroupsOutput {
+	return &ec2.DescribePlacementGroupsOutput{
+		PlacementGroups: []*ec2.PlacementGroup{
+			{
+				GroupName: aws.String(groupName),
+			},
+		},
+	}
+}
+
+func stubCreatePlacementGroupOutput(groupName string) *ec2.CreatePlacementGroupOutput {
+	return &ec2.CreatePlacementGroupOutput{
+		PlacementGroup: &ec2.PlacementGroup{
+			GroupName: aws.String(groupName),
+		},
+	}
+}
+
 func stubReservation(imageID, instanceID string, privateIP string) *ec2.Reservation {
 	az := defaultAvailabilityZone
 	return &ec2.Reservation{

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -281,6 +281,12 @@ func stubDescribePlacementGroupsOutput(groupName string) *ec2.DescribePlacementG
 		PlacementGroups: []*ec2.PlacementGroup{
 			{
 				GroupName: aws.String(groupName),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("kubernetes.io/cluster/" + stubClusterID),
+						Value: aws.String("owned"),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,6 +82,7 @@ type Client interface {
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	CreatePlacementGroup(*ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error)
+	DeletePlacementGroup(*ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error)
 
 	RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
 	ELBv2DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)
@@ -147,6 +148,10 @@ func (c *awsClient) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutpu
 
 func (c *awsClient) CreatePlacementGroup(input *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
 	return c.ec2Client.CreatePlacementGroup(input)
+}
+
+func (c *awsClient) DeletePlacementGroup(input *ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
+	return c.ec2Client.DeletePlacementGroup(input)
 }
 
 func (c *awsClient) RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -75,11 +75,13 @@ type Client interface {
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 	DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribePlacementGroups(*ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error)
 	RunInstances(*ec2.RunInstancesInput) (*ec2.Reservation, error)
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
+	CreatePlacementGroup(*ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error)
 
 	RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
 	ELBv2DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)
@@ -119,6 +121,10 @@ func (c *awsClient) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInpu
 	return c.ec2Client.DescribeSecurityGroups(input)
 }
 
+func (c *awsClient) DescribePlacementGroups(input *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
+	return c.ec2Client.DescribePlacementGroups(input)
+}
+
 func (c *awsClient) RunInstances(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
 	return c.ec2Client.RunInstances(input)
 }
@@ -137,6 +143,10 @@ func (c *awsClient) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.Descr
 
 func (c *awsClient) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	return c.ec2Client.CreateTags(input)
+}
+
+func (c *awsClient) CreatePlacementGroup(input *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
+	return c.ec2Client.CreatePlacementGroup(input)
 }
 
 func (c *awsClient) RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {

--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -113,6 +113,10 @@ func (c *awsClient) CreatePlacementGroup(input *ec2.CreatePlacementGroupInput) (
 	return &ec2.CreatePlacementGroupOutput{}, nil
 }
 
+func (c *awsClient) DeletePlacementGroup(input *ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
+	return &ec2.DeletePlacementGroupOutput{}, nil
+}
+
 func (c *awsClient) RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
 	// Feel free to extend the returned values
 	return &elb.RegisterInstancesWithLoadBalancerOutput{}, nil

--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -53,6 +53,10 @@ func (c *awsClient) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInpu
 	}, nil
 }
 
+func (c *awsClient) DescribePlacementGroups(*ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
+	return &ec2.DescribePlacementGroupsOutput{}, nil
+}
+
 func (c *awsClient) DescribeDHCPOptions(input *ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error) {
 	return machine.StubDescribeDHCPOptions()
 }
@@ -103,6 +107,10 @@ func (c *awsClient) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.Descr
 
 func (c *awsClient) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	return &ec2.CreateTagsOutput{}, nil
+}
+
+func (c *awsClient) CreatePlacementGroup(input *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
+	return &ec2.CreatePlacementGroupOutput{}, nil
 }
 
 func (c *awsClient) RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -36,6 +36,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CreatePlacementGroup mocks base method.
+func (m *MockClient) CreatePlacementGroup(arg0 *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePlacementGroup", arg0)
+	ret0, _ := ret[0].(*ec2.CreatePlacementGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePlacementGroup indicates an expected call of CreatePlacementGroup.
+func (mr *MockClientMockRecorder) CreatePlacementGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePlacementGroup", reflect.TypeOf((*MockClient)(nil).CreatePlacementGroup), arg0)
+}
+
 // CreateTags mocks base method.
 func (m *MockClient) CreateTags(arg0 *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	m.ctrl.T.Helper()
@@ -109,6 +124,21 @@ func (m *MockClient) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.D
 func (mr *MockClientMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockClient)(nil).DescribeInstances), arg0)
+}
+
+// DescribePlacementGroups mocks base method.
+func (m *MockClient) DescribePlacementGroups(arg0 *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribePlacementGroups", arg0)
+	ret0, _ := ret[0].(*ec2.DescribePlacementGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePlacementGroups indicates an expected call of DescribePlacementGroups.
+func (mr *MockClientMockRecorder) DescribePlacementGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePlacementGroups", reflect.TypeOf((*MockClient)(nil).DescribePlacementGroups), arg0)
 }
 
 // DescribeSecurityGroups mocks base method.

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -66,6 +66,21 @@ func (mr *MockClientMockRecorder) CreateTags(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockClient)(nil).CreateTags), arg0)
 }
 
+// DeletePlacementGroup mocks base method.
+func (m *MockClient) DeletePlacementGroup(arg0 *ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePlacementGroup", arg0)
+	ret0, _ := ret[0].(*ec2.DeletePlacementGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeletePlacementGroup indicates an expected call of DeletePlacementGroup.
+func (mr *MockClientMockRecorder) DeletePlacementGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePlacementGroup", reflect.TypeOf((*MockClient)(nil).DeletePlacementGroup), arg0)
+}
+
 // DescribeAvailabilityZones mocks base method.
 func (m *MockClient) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	m.ctrl.T.Helper()

--- a/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machine.crd.yaml
@@ -80,6 +80,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -98,6 +101,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -173,6 +173,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -191,6 +194,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/vendor/github.com/openshift/api/machine/v1beta1/types_awsprovider.go
+++ b/vendor/github.com/openshift/api/machine/v1beta1/types_awsprovider.go
@@ -177,6 +177,42 @@ type Placement struct {
 	// supported 3 options: default, dedicated and host.
 	// +optional
 	Tenancy InstanceTenancy `json:"tenancy,omitempty"`
+	// GroupName specifies the name of an AWS placement group to create the Machine within.
+	// If the group specified does not exist, it will be created based on the GroupType
+	// paramenter.
+	// When a Machine is deleted, if this leaves an empty Placement Group, the group is also
+	// deleted.
+	// +optional
+	GroupName string `json:"groupName,omitempty"`
+	// GroupType specifies the type of AWS placement group to use for this Machine.
+	// This parameter is only used when a Machine is being created and the named
+	// placement group does not exist.
+	// Valid values are "Cluster", "Partition", "Spread", and omitted, which means
+	// no opinion and the platform chooses a good default which may change over time.
+	// The current default value is "Spread".
+	// +kubebuilder:validation:Enum:="Cluster";"Partition";"Spread"
+	// +optional
+	GroupType AWSPlacementGroupType `json:"groupType,omitempty"`
+	// PartitionCount specifies the number of partitions for a Partition placement
+	// group. This value is only observed when creating a placement group and
+	// only when the `groupType` is set to `Partition`.
+	// Note the partition count of a placement group cannot be changed after creation.
+	// If unset, AWS will provide a default partition count.
+	// This default is currently 2.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=7
+	// +optional
+	PartitionCount int32 `json:"partitionCount,omitempty"`
+	// PartitionNumber specifies the numbered partition in which instances should be launched.
+	// This value is only used in conjunction with a `Partition` placement Group.
+	// It is recommended to only use this value if multiple MachineSets share
+	// a single Placement Group, in which case, each MachineSet should represent an individual partition number.
+	// If unset, when a Partition placement group is used, AWS will attempt to
+	// distribute instances evenly between partitions.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=7
+	// +optional
+	PartitionNumber int32 `json:"partitionNumber,omitempty"`
 }
 
 // Filter is a filter used to identify an AWS resource
@@ -233,6 +269,30 @@ const (
 const (
 	ClassicLoadBalancerType AWSLoadBalancerType = "classic" // AWS classic ELB
 	NetworkLoadBalancerType AWSLoadBalancerType = "network" // AWS Network Load Balancer (NLB)
+)
+
+// AWSPlacementGroupType represents the valid values for the Placement GroupType field.
+type AWSPlacementGroupType string
+
+const (
+	// AWSClusterPlacementGroupType is the "Cluster" placement group type.
+	// Cluster placement groups place instances close together to improve network latency and throughput.
+	AWSClusterPlacementGroupType AWSPlacementGroupType = "Cluster"
+	// AWSPartitionPlacementGroupType is the "Partition" placement group type.
+	// Partition placement groups reduce the likelihood of hardware failures
+	// disrupting your application's availability.
+	// Partition placement groups are recommended for use with large scale
+	// distributed and replicated workloads.
+	AWSPartitionPlacementGroupType AWSPlacementGroupType = "Partition"
+	// AWSSpreadPlacementGroupType is the "Spread" placement group type.
+	// Spread placement groups place instances on distinct racks within the availability
+	// zone. This ensures instances each have their own networking and power source
+	// for maximum hardware fault tolerance.
+	// Spread placement groups are recommended for a small number of critical instances
+	// which must be kept separate from one another.
+	// Using a Spread placement group imposes a limit of seven instances within
+	// the placement group within a single availability zone.
+	AWSSpreadPlacementGroupType AWSPlacementGroupType = "Spread"
 )
 
 // AWSMachineProviderStatus is the type that will be embedded in a Machine.Status.ProviderStatus field.

--- a/vendor/github.com/openshift/api/machine/v1beta1/types_machine.go
+++ b/vendor/github.com/openshift/api/machine/v1beta1/types_machine.go
@@ -222,7 +222,7 @@ type LifecycleHook struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=256
-	// +required
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
 	// Owner defines the owner of the lifecycle hook.
@@ -232,7 +232,7 @@ type LifecycleHook struct {
 	// or an administrator managing the hook.
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=512
-	// +required
+	// +kubebuilder:validation:Required
 	Owner string `json:"owner"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -253,7 +253,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift/api v0.0.0-20211217221424-8779abfbd571
+# github.com/openshift/api v0.0.0-20211217221424-8779abfbd571 => github.com/JoelSpeed/api v0.0.0-20220107173117-d1bbaa7a5511
 ## explicit; go 1.16
 github.com/openshift/api/config/v1
 github.com/openshift/api/machine/v1beta1
@@ -925,3 +925,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/openshift/api => github.com/JoelSpeed/api v0.0.0-20220107173117-d1bbaa7a5511


### PR DESCRIPTION
When we remove a machine, we should also make sure that its placement group is also deleted, but only if it doesn't contain other machines.