### PR TITLE
Ensure Machine level tags have precedence over infrastructure level tags

### DIFF
--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -1087,7 +1087,7 @@ func TestCorrectExistingTags(t *testing.T) {
 	testCases := []struct {
 		name               string
 		tags               []*ec2.Tag
-		userTags           map[string]string
+		userTags           []*ec2.Tag
 		expectedCreateTags bool
 	}{
 		{
@@ -1117,7 +1117,12 @@ func TestCorrectExistingTags(t *testing.T) {
 				},
 			},
 			expectedCreateTags: true,
-			userTags:           map[string]string{"UserDefinedTag2": "UserDefinedTagValue2"},
+			userTags: []*ec2.Tag{
+				{
+					Key:   aws.String("UserDefinedTag2"),
+					Value: aws.String("UserDefinedTagValue2"),
+				},
+			},
 		},
 		{
 			name: "Valid Tags and Update",
@@ -1136,7 +1141,12 @@ func TestCorrectExistingTags(t *testing.T) {
 				},
 			},
 			expectedCreateTags: true,
-			userTags:           map[string]string{"UserDefinedTag1": "ModifiedValue"},
+			userTags: []*ec2.Tag{
+				{
+					Key:   aws.String("UserDefinedTag1"),
+					Value: aws.String("ModifiedValue"),
+				},
+			},
 		},
 		{
 			name: "Invalid Name Tag Correct Cluster",

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
 	awsclient "github.com/openshift/machine-api-provider-aws/pkg/client"
 	corev1 "k8s.io/api/core/v1"
@@ -211,12 +212,20 @@ func (r *Reconciler) update() error {
 	runningLen := len(runningInstances)
 	var newestInstance *ec2.Instance
 
-	// Prepare the tag list with infrastructure tags.
-	// These tags will be used to update the EC2 instance tags.
-	tagList, err := r.getTagsFromInfrastructure()
-	if err != nil {
+	clusterID, ok := getClusterID(r.machine)
+	if !ok {
+		klog.Errorf("Unable to get cluster ID for machine: %q", r.machine.Name)
+		return mapierrors.InvalidMachineConfiguration("Unable to get cluster ID for machine: %q", r.machine.Name)
+	}
+
+	infra := &configv1.Infrastructure{}
+	infraName := client.ObjectKey{Name: awsclient.GlobalInfrastuctureName}
+	if err := r.client.Get(r.Context, infraName, infra); err != nil {
 		return err
 	}
+
+	// These tags will be used to update the EC2 instance tags.
+	tagList := buildTagList(r.machine.Name, clusterID, r.providerSpec.Tags, infra)
 
 	if runningLen > 0 {
 		// It would be very unusual to have more than one here, but it is
@@ -256,25 +265,6 @@ func (r *Reconciler) update() error {
 	r.machineScope.setProviderStatus(newestInstance, conditionSuccess())
 
 	return r.requeueIfInstancePending(newestInstance)
-}
-
-func (r *Reconciler) getTagsFromInfrastructure() (map[string]string, error) {
-	infra := &configv1.Infrastructure{}
-	infraName := client.ObjectKey{Name: awsclient.GlobalInfrastuctureName}
-
-	if err := r.client.Get(r.Context, infraName, infra); err != nil {
-		return nil, fmt.Errorf("error fetching Infrastructure %q: %v", infraName.Name, err)
-	}
-	tags := make(map[string]string)
-	resourceTags, ok := fetchInfraResourceTags(infra)
-	if !ok {
-		return tags, nil
-	}
-
-	for _, value := range resourceTags {
-		tags[value.Key] = value.Value
-	}
-	return tags, nil
 }
 
 // exists returns true if machine exists.

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -136,7 +136,12 @@ func getInstanceByID(id string, client awsclient.Client, instanceStateFilter []*
 
 // correctExistingTags validates Name and clusterID tags are correct on the instance
 // and sets them if they are not.
-func correctExistingTags(machine *machinev1.Machine, instance *ec2.Instance, client awsclient.Client, tags map[string]string) error {
+func correctExistingTags(machine *machinev1.Machine, instance *ec2.Instance, client awsclient.Client, rawTags []*ec2.Tag) error {
+	tags := make(map[string]string)
+	for _, tag := range rawTags {
+		tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.CreateTags
 	if instance == nil || instance.InstanceId == nil {
 		return fmt.Errorf("unexpected nil found in instance: %v", instance)


### PR DESCRIPTION
#15 introduced a change to ensure tags are updated post Machine creation. However, it didn't account for the tags in the Machine spec as we do on create, as such, any tags set on the Machine themselves were removed on first update and discarded.

This resolves the issue so now the tags from the Machine spec are included as they were before