### PR TITLE
Bug 2065160: Ensure IP based NLB targets are deregistered before Machines are removed

### DIFF
--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -307,6 +307,17 @@ func stubDescribeTargetHealthOutput() *elbv2.DescribeTargetHealthOutput {
 	return &elbv2.DescribeTargetHealthOutput{}
 }
 
+func stubDeregisterTargetsInput(ipAddr string) *elbv2.DeregisterTargetsInput {
+	return &elbv2.DeregisterTargetsInput{
+		TargetGroupArn: aws.String("arn2"),
+		Targets: []*elbv2.TargetDescription{
+			{
+				Id: aws.String(ipAddr),
+			},
+		},
+	}
+}
+
 func stubReservation(imageID, instanceID string, privateIP string) *ec2.Reservation {
 	az := defaultAvailabilityZone
 	return &ec2.Reservation{


### PR DESCRIPTION
Currently, if we fail to deregister the NLB target, we might leak the instance because we terminate the instance before the NLB target is deregistered.

We should not be removing the machine until the NLB targets have been deregistered.

Turns out there were no tests for delete, so I've added some so that we can test this.