### PR TITLE
[OCPCLOUD-1159] Validate unknown regions using AWS API

### DIFF
--- a/pkg/actuators/awsplacementgroup/controller.go
+++ b/pkg/actuators/awsplacementgroup/controller.go
@@ -52,8 +52,9 @@ type Reconciler struct {
 	AWSClientBuilder    awsclient.AwsClientBuilderFuncType
 	ConfigManagedClient client.Client
 
-	recorder record.EventRecorder
-	scheme   *runtime.Scheme
+	regionCache awsclient.RegionCache
+	recorder    record.EventRecorder
+	scheme      *runtime.Scheme
 }
 
 // SetupWithManager creates a new controller for a manager.
@@ -112,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	awsClient, err := r.AWSClientBuilder(
 		r.Client, credentialsSecretName, awsPlacementGroup.Namespace,
-		infra.Status.PlatformStatus.AWS.Region, r.ConfigManagedClient)
+		infra.Status.PlatformStatus.AWS.Region, r.ConfigManagedClient, r.regionCache)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not create aws client: %w", err)
 	}

--- a/pkg/actuators/awsplacementgroup/controller_test.go
+++ b/pkg/actuators/awsplacementgroup/controller_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/machine-api-provider-aws/pkg/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -24,8 +25,9 @@ var _ = Describe("Reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		r := Reconciler{
-			Client: mgr.GetClient(),
-			Log:    log.Log,
+			Client:      mgr.GetClient(),
+			Log:         log.Log,
+			regionCache: client.NewRegionCache(),
 		}
 		Expect(r.SetupWithManager(mgr, controller.Options{})).To(Succeed())
 

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -43,6 +43,7 @@ type Actuator struct {
 	eventRecorder       record.EventRecorder
 	awsClientBuilder    awsclient.AwsClientBuilderFuncType
 	configManagedClient runtimeclient.Client
+	regionCache         awsclient.RegionCache
 }
 
 // ActuatorParams holds parameter information for Actuator.
@@ -60,6 +61,7 @@ func NewActuator(params ActuatorParams) *Actuator {
 		eventRecorder:       params.EventRecorder,
 		awsClientBuilder:    params.AwsClientBuilder,
 		configManagedClient: params.ConfigManagedClient,
+		regionCache:         awsclient.NewRegionCache(),
 	}
 }
 
@@ -82,6 +84,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1beta1.Machine) 
 		machine:             machine,
 		awsClientBuilder:    a.awsClientBuilder,
 		configManagedClient: a.configManagedClient,
+		regionCache:         a.regionCache,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -108,6 +111,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1beta1.Machine) 
 		machine:             machine,
 		awsClientBuilder:    a.awsClientBuilder,
 		configManagedClient: a.configManagedClient,
+		regionCache:         a.regionCache,
 	})
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -124,6 +128,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1beta1.Machine) 
 		machine:             machine,
 		awsClientBuilder:    a.awsClientBuilder,
 		configManagedClient: a.configManagedClient,
+		regionCache:         a.regionCache,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -163,6 +168,7 @@ func (a *Actuator) Delete(ctx context.Context, machine *machinev1beta1.Machine) 
 		machine:             machine,
 		awsClientBuilder:    a.awsClientBuilder,
 		configManagedClient: a.configManagedClient,
+		regionCache:         a.regionCache,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -170,11 +170,11 @@ func TestMachineEvents(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
 			mockAWSClient := mockaws.NewMockClient(mockCtrl)
-			awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+			awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 				return mockAWSClient, nil
 			}
 			if tc.invalidMachineScope {
-				awsClientBuilder = func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder = func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return nil, errors.New("AWS client error")
 				}
 			}

--- a/pkg/actuators/machine/controller_test.go
+++ b/pkg/actuators/machine/controller_test.go
@@ -26,7 +26,7 @@ func TestMachineControllerWithDelayedExistSuccess(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mockAWSClient := mockaws.NewMockClient(mockCtrl)
-	awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+	awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 		return mockAWSClient, nil
 	}
 

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -33,6 +33,8 @@ type machineScopeParams struct {
 	machine *machinev1beta1.Machine
 	// api server controller runtime client for the openshift-config-managed namespace
 	configManagedClient runtimeclient.Client
+	// cache for DescribeRegions API call results
+	regionCache awsclient.RegionCache
 }
 
 type machineScope struct {
@@ -66,7 +68,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		credentialsSecretName = providerSpec.CredentialsSecret.Name
 	}
 
-	awsClient, err := params.awsClientBuilder(params.client, credentialsSecretName, params.machine.Namespace, providerSpec.Placement.Region, params.configManagedClient)
+	awsClient, err := params.awsClientBuilder(params.client, credentialsSecretName, params.machine.Namespace, providerSpec.Placement.Region, params.configManagedClient, params.regionCache)
 	if err != nil {
 		return nil, machineapierros.InvalidMachineConfiguration("failed to create aws client: %v", err.Error())
 	}

--- a/pkg/actuators/machine/machine_scope_test.go
+++ b/pkg/actuators/machine/machine_scope_test.go
@@ -261,7 +261,7 @@ func TestPatchMachine(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  k8sClient,
 				machine: machine,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return nil, nil
 				},
 			})

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -99,7 +99,7 @@ func TestAvailabilityZone(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: machine,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return mockAWSClient, nil
 				},
 			})
@@ -490,7 +490,7 @@ func TestCreate(t *testing.T) {
 		machineScope, err := newMachineScope(machineScopeParams{
 			client:  fakeClient,
 			machine: machine,
-			awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+			awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 				return mockAWSClient, nil
 			},
 		})
@@ -624,7 +624,7 @@ func TestExists(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: tc.machine(),
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return tc.awsClient(ctrl), nil
 				},
 			})
@@ -733,7 +733,7 @@ func TestUpdate(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: tc.machine(),
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return tc.awsClient(ctrl), nil
 				},
 			})
@@ -890,7 +890,7 @@ func TestDelete(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: tc.machine(),
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return tc.awsClient(ctrl), nil
 				},
 			})
@@ -1028,7 +1028,7 @@ func TestGetMachineInstances(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: machineCopy,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 					return mockAWSClient, nil
 				},
 			})

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/openshift/machine-api-provider-aws/pkg/version"
 	corev1 "k8s.io/api/core/v1"
@@ -62,10 +64,12 @@ const (
 	kubeCloudConfigName = "kube-cloud-config"
 	// cloudCABundleKey is the key in the kube cloud config ConfigMap where the custom CA bundle is located
 	cloudCABundleKey = "ca-bundle.pem"
+	// awsRegionsCacheExpirationDuration is the duration for which the AWS regions cache is valid
+	awsRegionsCacheExpirationDuration = time.Minute * 30
 )
 
 // AwsClientBuilderFuncType is function type for building aws client
-type AwsClientBuilderFuncType func(client client.Client, secretName, namespace, region string, configManagedClient client.Client) (Client, error)
+type AwsClientBuilderFuncType func(client client.Client, secretName, namespace, region string, configManagedClient client.Client, regionCache RegionCache) (Client, error)
 
 // Client is a wrapper object for actual AWS SDK clients to allow for easier testing.
 type Client interface {
@@ -220,21 +224,120 @@ func NewClientFromKeys(accessKey, secretAccessKey, region string) (Client, error
 	}, nil
 }
 
+// DescribeRegionsData holds output of DescribeRegions API call and the time when it was last updated.
+type DescribeRegionsData struct {
+	err                   error
+	describeRegionsOutput *ec2.DescribeRegionsOutput
+	lastUpdated           time.Time
+}
+
+type regionCache struct {
+	data  map[string]DescribeRegionsData
+	mutex sync.RWMutex
+}
+
+// RegionCache caches successful DescribeRegions API calls.
+type RegionCache interface {
+	GetCachedDescribeRegions(awsSession *session.Session) (*ec2.DescribeRegionsOutput, error)
+}
+
+// NewRegionCache creates a new empty DescribeRegionsData cache with lock.
+func NewRegionCache() RegionCache {
+	return &regionCache{
+		data:  map[string]DescribeRegionsData{},
+		mutex: sync.RWMutex{},
+	}
+}
+
+// GetCachedDescribeRegions returns DescribeRegionsOutput from DescribeRegions AWS API call.
+// It is cached to avoid AWS API calls on each reconcile loop.
+func (c *regionCache) GetCachedDescribeRegions(awsSession *session.Session) (*ec2.DescribeRegionsOutput, error) {
+	creds, err := awsSession.Config.Credentials.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	regionData := c.data[creds.AccessKeyID]
+	if regionData.describeRegionsOutput != nil && regionData.err == nil &&
+		time.Since(regionData.lastUpdated) < awsRegionsCacheExpirationDuration {
+		klog.Info("Using cached AWS region data")
+		return regionData.describeRegionsOutput, nil
+	}
+
+	currentRegion := awsSession.Config.Region
+	// Use default region to send our request
+	awsSession.Config.Region = aws.String("us-east-1")
+	describeRegionsOutput, err := ec2.New(awsSession).DescribeRegions(&ec2.DescribeRegionsInput{
+		AllRegions: aws.Bool(true),
+		DryRun:     aws.Bool(false),
+	})
+	// Restore the original region
+	awsSession.Config.Region = currentRegion
+	if err != nil {
+		regionData.err = err
+		return nil, err
+	}
+
+	regionData.describeRegionsOutput = describeRegionsOutput
+	regionData.lastUpdated = time.Now()
+	c.data[creds.AccessKeyID] = regionData
+	return describeRegionsOutput, nil
+}
+
+// Check that region is in the DescribeRegions list and is opted in.
+func validateRegion(describeRegionsOutput *ec2.DescribeRegionsOutput, region string) (*ec2.Region, error) {
+	var regionData *ec2.Region
+	for _, currentRegion := range describeRegionsOutput.Regions {
+		if currentRegion != nil && *currentRegion.RegionName == region {
+			regionData = currentRegion
+			break
+		}
+	}
+
+	if regionData == nil {
+		return nil, fmt.Errorf("region %s is not a valid region", region)
+	}
+	if *regionData.OptInStatus == "not-opted-in" {
+		return nil, fmt.Errorf("region %s is not opted in", region)
+	}
+	klog.Infof("AWS reports region %s is valid", region)
+	return regionData, nil
+}
+
 // NewValidatedClient creates our client wrapper object for the actual AWS clients we use.
 // This should behave the same as NewClient except it will validate the client configuration
 // (eg the region) before returning the client.
-func NewValidatedClient(ctrlRuntimeClient client.Client, secretName, namespace, region string, configManagedClient client.Client) (Client, error) {
+func NewValidatedClient(ctrlRuntimeClient client.Client, secretName, namespace, region string, configManagedClient client.Client, regionCache RegionCache) (Client, error) {
 	s, err := newAWSSession(ctrlRuntimeClient, secretName, namespace, region, configManagedClient)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check that the endpoint can be resolved by the endpoint resolver.
+	// If the endpoint is not resolvable locally, we try to validate using the AWS API.
 	// If the endpoint is not known, it is not a standard or configured custom region.
-	// If this is the case, the client will likely not be able to connect
+	// In that case, the client will likely not be able to connect
 	_, err = s.Config.EndpointResolver.EndpointFor("ec2", region, func(opts *endpoints.Options) {
 		opts.StrictMatching = true
 	})
+	if err != nil {
+		switch err.(type) {
+		case endpoints.UnknownEndpointError:
+			klog.Infof("Region %s is not recognized by aws-sdk, trying to validate using API", region)
+			var describeRegionsOutput *ec2.DescribeRegionsOutput
+			describeRegionsOutput, err = regionCache.GetCachedDescribeRegions(s)
+			if err != nil {
+				return nil, fmt.Errorf("could not retrieve region data: %w", err)
+			}
+
+			_, err = validateRegion(describeRegionsOutput, region)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("region %q not resolved: %w", region, err)
 	}

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -7,6 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
+	session "github.com/aws/aws-sdk-go/aws/session"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	elb "github.com/aws/aws-sdk-go/service/elb"
 	elbv2 "github.com/aws/aws-sdk-go/service/elbv2"
@@ -334,4 +335,42 @@ func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2
 func (mr *MockClientMockRecorder) TerminateInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockClient)(nil).TerminateInstances), arg0)
+}
+
+// MockRegionCache is a mock of RegionCache interface.
+type MockRegionCache struct {
+	ctrl     *gomock.Controller
+	recorder *MockRegionCacheMockRecorder
+}
+
+// MockRegionCacheMockRecorder is the mock recorder for MockRegionCache.
+type MockRegionCacheMockRecorder struct {
+	mock *MockRegionCache
+}
+
+// NewMockRegionCache creates a new mock instance.
+func NewMockRegionCache(ctrl *gomock.Controller) *MockRegionCache {
+	mock := &MockRegionCache{ctrl: ctrl}
+	mock.recorder = &MockRegionCacheMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRegionCache) EXPECT() *MockRegionCacheMockRecorder {
+	return m.recorder
+}
+
+// GetCachedDescribeRegions mocks base method.
+func (m *MockRegionCache) GetCachedDescribeRegions(awsSession *session.Session) (*ec2.DescribeRegionsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCachedDescribeRegions", awsSession)
+	ret0, _ := ret[0].(*ec2.DescribeRegionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCachedDescribeRegions indicates an expected call of GetCachedDescribeRegions.
+func (mr *MockRegionCacheMockRecorder) GetCachedDescribeRegions(awsSession interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedDescribeRegions", reflect.TypeOf((*MockRegionCache)(nil).GetCachedDescribeRegions), awsSession)
 }


### PR DESCRIPTION
When region cannot be validated locally from vendored aws/endpoints/defaults.go call AWS describeRegions API
to get list of regions and validate requested region with it.

This allows new AWS regions to work on older versions of OpenShift
without having to backport AWS SDK.

Requires https://github.com/openshift/machine-api-operator/pull/1007 to merge first