### PR TITLE
Bug 2072195: Custom DHCP Option Set: empty domain-name is a valid custom domain

### DIFF
--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -176,7 +176,6 @@ func (s *machineScope) setProviderStatus(instance *ec2.Instance, condition metav
 		s.providerStatus.InstanceState = instance.State.Name
 
 		domainNames, err := s.getCustomDomainFromDHCP(instance.VpcId)
-
 		if err != nil {
 			return err
 		}
@@ -227,5 +226,8 @@ func (s *machineScope) getCustomDomainFromDHCP(vpcID *string) ([]string, error) 
 			return strings.Split(*i.Values[0].Value, " "), nil
 		}
 	}
-	return nil, nil
+	// If we are here it means a valid DHCPOption exists but there is no DhcpConfiguration in it with the `dhcpDomainKeyName`
+	// this means the DHCPOption has an empty `domain-name`, which is a valid configuration for it.
+	// As such, we return it as a valid empty domain.
+	return []string{""}, nil
 }

--- a/pkg/actuators/machine/machine_scope_test.go
+++ b/pkg/actuators/machine/machine_scope_test.go
@@ -340,7 +340,7 @@ func TestGetCustomDomainFromDHCP(t *testing.T) {
 			t.Errorf("error when calling getCustomDomainFromDHCP: %v", err)
 		}
 		if !reflect.DeepEqual(got, tc.expected) {
-			t.Errorf("Case: %s. Got: %v, expected: %v", tc.description, got, tc.expected)
+			t.Errorf("Case: %s. Got: %#v, expected: %#v", tc.description, got, tc.expected)
 		}
 	}
 }

--- a/pkg/actuators/machine/machine_scope_test.go
+++ b/pkg/actuators/machine/machine_scope_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -297,37 +298,76 @@ func TestGetCustomDomainFromDHCP(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockAWSClient := mockaws.NewMockClient(mockCtrl)
 	dhcpID := "someID"
-	expectedDomains := "openshift.com openshift.io"
 	mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(&ec2.DescribeVpcsOutput{
 		Vpcs: []*ec2.Vpc{
 			{DhcpOptionsId: &dhcpID},
 		},
 	}, nil).AnyTimes()
 
-	mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(&ec2.DescribeDhcpOptionsOutput{
-		DhcpOptions: []*ec2.DhcpOptions{
-			{
-				DhcpConfigurations: []*ec2.DhcpConfiguration{
+	testCases := []struct {
+		description               string
+		describeDhcpOptionsOutput ec2.DescribeDhcpOptionsOutput
+		expected                  []string
+	}{
+		{
+			description: "Returns two",
+			expected:    []string{"openshift.com", "openshift.io"},
+			describeDhcpOptionsOutput: ec2.DescribeDhcpOptionsOutput{
+				DhcpOptions: []*ec2.DhcpOptions{
 					{
-						Key: &dhcpDomainKeyName,
-						Values: []*ec2.AttributeValue{
+						DhcpConfigurations: []*ec2.DhcpConfiguration{
 							{
-								Value: &expectedDomains,
+								Key: &dhcpDomainKeyName,
+								Values: []*ec2.AttributeValue{
+									{
+										Value: aws.String("openshift.com openshift.io"),
+									},
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-	}, nil).AnyTimes()
-
-	testCases := []struct {
-		description string
-		expected    []string
-	}{
 		{
-			description: "Returns two",
-			expected:    []string{"openshift.com", "openshift.io"},
+			description: "Returns one",
+			expected:    []string{"openshift.com"},
+			describeDhcpOptionsOutput: ec2.DescribeDhcpOptionsOutput{
+				DhcpOptions: []*ec2.DhcpOptions{
+					{
+						DhcpConfigurations: []*ec2.DhcpConfiguration{
+							{
+								Key: &dhcpDomainKeyName,
+								Values: []*ec2.AttributeValue{
+									{
+										Value: aws.String("openshift.com"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Returns a valid empty domain when domain-name is missing but domain-name-servers exists",
+			expected:    []string{""},
+			describeDhcpOptionsOutput: ec2.DescribeDhcpOptionsOutput{
+				DhcpOptions: []*ec2.DhcpOptions{
+					{
+						DhcpConfigurations: []*ec2.DhcpConfiguration{
+							{
+								Key: aws.String("domain-name-servers"),
+								Values: []*ec2.AttributeValue{
+									{
+										Value: aws.String("AmazonProvidedDNS"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -335,6 +375,9 @@ func TestGetCustomDomainFromDHCP(t *testing.T) {
 		mS := machineScope{
 			awsClient: mockAWSClient,
 		}
+
+		mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(&tc.describeDhcpOptionsOutput, nil).AnyTimes()
+
 		got, err := mS.getCustomDomainFromDHCP(nil)
 		if err != nil {
 			t.Errorf("error when calling getCustomDomainFromDHCP: %v", err)

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -373,7 +373,10 @@ func extractNodeAddresses(instance *ec2.Instance, domainNames []string) ([]corev
 		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: privateDNSName})
 		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeHostName, Address: privateDNSName})
 		for _, dn := range domainNames {
-			customHostName := strings.Join([]string{strings.Split(privateDNSName, ".")[0], dn}, ".")
+			customHostName := strings.Split(privateDNSName, ".")[0]
+			if dn != "" {
+				customHostName += "." + dn
+			}
 			if customHostName != privateDNSName {
 				addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: customHostName})
 			}

--- a/pkg/actuators/machine/utils_test.go
+++ b/pkg/actuators/machine/utils_test.go
@@ -84,6 +84,30 @@ func TestExtractNodeAddresses(t *testing.T) {
 			domainNames: []string{"openshift.com", "openshift.io"},
 		},
 		{
+			testcase: "custom-domain that is empty",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2"},
+			},
+			domainNames: []string{""},
+		},
+		{
 			testcase: "custom-domain no duplicates",
 			instance: &ec2.Instance{
 				PrivateDnsName: aws.String("ec2.example.net"),


### PR DESCRIPTION
This PR fixes a bug reported at https://bugzilla.redhat.com/show_bug.cgi?id=2072195 where adding an empty domain-name in a Custom DHCP Option Set wrongfully ends up breaking the CSR validation for nodes created afterwards.

We know that if a DHCP Options Set does not contain a `domain-name` key, then the metadata service, used by the legacy cloud provider to populate Node.Addresses and therefore the CSR, will not contain a domain. We need Machine.Addresses to contain a corresponding value in this case in order to validate the CSR.

Here we return an Address with an explicit empty trailing domain name iff we have DHCP Options Set with no `domain-name` key, which we add as a NodeInternalDNS (and Hostname) (without a trailing '.').

Note: Bug (and fix) reproduction and verification steps are available on the bug report.

Bug Reproduction (0.00 -> 2.15) and Bug resolution Verification (2.15 -> till end):

https://user-images.githubusercontent.com/4902157/167406867-38aba0cd-6826-48d7-8899-5d223ee64ea0.mp4


