### PR TITLE
pkg/actuators/machineset/controller: Fix %s in scale-from-zero logging

### DIFF
--- a/pkg/actuators/machineset/controller.go
+++ b/pkg/actuators/machineset/controller.go
@@ -112,8 +112,8 @@ func (r *Reconciler) reconcile(machineSet *machinev1beta1.MachineSet) (ctrl.Resu
 	}
 	instanceType, ok := InstanceTypes[providerConfig.InstanceType]
 	if !ok {
-		klog.Error("Unable to set scale from zero annotations: unknown instance type: %s", providerConfig.InstanceType)
-		klog.Error("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
+		klog.Errorf("Unable to set scale from zero annotations: unknown instance type: %s", providerConfig.InstanceType)
+		klog.Errorf("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
 
 		// Returning no error to prevent further reconciliation, as user intervention is now required but emit an informational event
 		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedUpdate", "Failed to set autoscaling from zero annotations, instance type unknown")


### PR DESCRIPTION
Use `Errorf` to get the `%s` and `%v` formatting, avoiding logs like:

    Unable to set scale from zero annotations: unknown instance type: %sm6a.8xlarge

where the `Error` was treating the `%s` as a literal, and not as a format placeholder.

Generated wth:

```console
$ sed -i 's/klog.Error(\(.*%\)/klog.Errorf(\1/' $(git grep -l 'klog.Error(.*%')
```