### PR TITLE
Bug 2060068: check securityGroupIDs for emptiness

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -92,7 +92,7 @@ func getSecurityGroupsIDs(securityGroups []machinev1beta1.AWSResourceReference, 
 		}
 	}
 
-	if len(securityGroups) == 0 {
+	if len(securityGroupIDs) == 0 {
 		klog.Error("No security group found")
 		return nil, fmt.Errorf("no security group found")
 	}


### PR DESCRIPTION
Now we check securityGroups parameter, which contains a list of SG filters. Instead, we shoud check the list of IDs that we get from the server.