### PR TITLE
Bug 2106733: Fix panic when accessing nil machine annotations map

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -160,6 +160,10 @@ func (r *Reconciler) delete() error {
 		return fmt.Errorf("failed to delete instaces: %w", err)
 	}
 
+	if r.machine.Annotations == nil {
+		r.machine.Annotations = make(map[string]string)
+	}
+
 	if len(terminatingInstances) == 1 {
 		if terminatingInstances[0] != nil && terminatingInstances[0].CurrentState != nil && terminatingInstances[0].CurrentState.Name != nil {
 			r.machine.Annotations[machinecontroller.MachineInstanceStateAnnotationName] = aws.StringValue(terminatingInstances[0].CurrentState.Name)


### PR DESCRIPTION
This is a bug fix for panic when deleting a machine and trying to access a value from its annotations while the map is not initialized.