### PR TITLE
Update Machine API Operator dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20220628012702-9368b92de0ab
-	github.com/openshift/machine-api-operator v0.2.1-0.20220808213825-1c83be8e1625
+	github.com/openshift/machine-api-operator v0.2.1-0.20220908234044-1e96229babda
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf h1:gAYYPWVduON
 github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
-github.com/openshift/machine-api-operator v0.2.1-0.20220808213825-1c83be8e1625 h1:cn1JZJHdQbC5l3Zj/wKD7NVLjposubdmvDgckrqS8sg=
-github.com/openshift/machine-api-operator v0.2.1-0.20220808213825-1c83be8e1625/go.mod h1:euIIULkt0ijd4SakPntuZxGXNLxk1dUQ4je6r6igd4c=
+github.com/openshift/machine-api-operator v0.2.1-0.20220908234044-1e96229babda h1:JtdKcaFB63WyWNng07NKrMdx3WXa6qh+VjhXNRq25vI=
+github.com/openshift/machine-api-operator v0.2.1-0.20220908234044-1e96229babda/go.mod h1:euIIULkt0ijd4SakPntuZxGXNLxk1dUQ4je6r6igd4c=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -282,7 +282,7 @@ github.com/openshift/client-go/machine/listers/machine/v1beta1
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/leaderelection
-# github.com/openshift/machine-api-operator v0.2.1-0.20220808213825-1c83be8e1625
+# github.com/openshift/machine-api-operator v0.2.1-0.20220908234044-1e96229babda
 ## explicit; go 1.18
 github.com/openshift/machine-api-operator/pkg/controller/machine
 github.com/openshift/machine-api-operator/pkg/metrics


### PR DESCRIPTION
This bumps the MAO dependency to include the new changes for only draining a single control plane machine at once

XREF: openshift/machine-api-operator#1066