### PR TITLE
OCPBUGS-6882: Log to user that the subnet id and zone fields are mismatched

### DIFF
--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -222,6 +222,7 @@ func TestMachineEvents(t *testing.T) {
 			mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 			mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
 			mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+			mockAWSClient.EXPECT().DescribeSubnets(gomock.Any()).Return(&ec2.DescribeSubnetsOutput{}, nil).AnyTimes()
 
 			params := ActuatorParams{
 				Client:           k8sClient,
@@ -258,6 +259,9 @@ func TestHandleMachineErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	mockCtrl := gomock.NewController(t)
+	mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
 	cases := []struct {
 		name        string
 		eventAction string
@@ -273,6 +277,8 @@ func TestHandleMachineErrors(t *testing.T) {
 			eventAction: "",
 		},
 	}
+
+	mockAWSClient.EXPECT().DescribeSubnets(gomock.Any()).Return(&ec2.DescribeSubnetsOutput{}, nil).AnyTimes()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/actuators/machine/controller_test.go
+++ b/pkg/actuators/machine/controller_test.go
@@ -48,6 +48,7 @@ func TestMachineControllerWithDelayedExistSuccess(t *testing.T) {
 		mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(stubDescribeTargetHealthOutput(), nil).AnyTimes()
 		mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 		mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
+		mockAWSClient.EXPECT().DescribeSubnets(gomock.Any()).Return(&ec2.DescribeSubnetsOutput{}, nil).AnyTimes()
 
 		// After create, we will assert that the instance doesn't exist for the first 3 times that the call is made
 		// - The first call is Exists, which will return that the instance does not exist

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -108,12 +108,12 @@ func getSubnetIDs(machine runtimeclient.ObjectKey, subnet machinev1beta1.AWSReso
 
 		availabilityZoneFromSubnetID, err := getAvalabilityZoneFromSubnetID(availabilityZone, client)
 		if err != nil {
-			klog.Errorf("could not check if the subnet id and availability zone fields are mismatched")
+			klog.Errorf("could not check if the subnet id and availability zone fields are mismatched: %w", err)
 			return subnetIDs, nil
 		}
 
 		if availabilityZone != availabilityZoneFromSubnetID {
-			klog.Errorf("mismatched subnet id and availibity zone")
+			klog.Errorf("mismatched subnet id %s and availibity zone %s", *subnet.ID, availabilityZone)
 		}
 	} else {
 		var filters []machinev1beta1.Filter
@@ -171,7 +171,7 @@ func getAvalabilityZoneFromSubnetID(subnetID string, client awsclient.Client) (s
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("could not describe a subnet")
+		return "", fmt.Errorf("could not describe a subnet: %w", err)
 	}
 
 	if result == nil {

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -197,6 +197,7 @@ func TestCreate(t *testing.T) {
 	mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 	mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
+	mockAWSClient.EXPECT().DescribeSubnets(gomock.Any()).Return(&ec2.DescribeSubnetsOutput{}, nil).AnyTimes()
 
 	testCases := []struct {
 		testcase             string


### PR DESCRIPTION
Right now if these 2 fields are mismatched, the machine gets to running with no issues. This fix proposes additional logic to determine whether the `subnetID` and `a.Zone` are the same value. If not, we log an message to the controller so the user can see it.