### PR TITLE
OCPBUGS-11223: Reduce metrics cardinality

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -118,7 +118,7 @@ func getSubnetIDs(machine runtimeclient.ObjectKey, subnet machinev1beta1.AWSReso
 				metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 					Name:      machine.Name,
 					Namespace: machine.Namespace,
-					Reason:    err.Error(),
+					Reason:    "error describing availability zones",
 				})
 				klog.Errorf("error describing availability zones: %v", err)
 				return nil, fmt.Errorf("error describing availability zones: %v", err)
@@ -135,9 +135,9 @@ func getSubnetIDs(machine runtimeclient.ObjectKey, subnet machinev1beta1.AWSReso
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      machine.Name,
 				Namespace: machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "error describing subnets",
 			})
-			klog.Errorf("error describing subnetes: %v", err)
+			klog.Errorf("error describing subnets: %v", err)
 			return nil, fmt.Errorf("error describing subnets: %v", err)
 		}
 		for _, n := range describeSubnetResult.Subnets {
@@ -167,7 +167,7 @@ func getAMI(machine runtimeclient.ObjectKey, AMI machinev1beta1.AWSResourceRefer
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      machine.Name,
 				Namespace: machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "error describing AMI",
 			})
 			klog.Errorf("error describing AMI: %v", err)
 			return nil, fmt.Errorf("error describing AMI: %v", err)
@@ -214,7 +214,7 @@ func getBlockDeviceMappings(machine runtimeclient.ObjectKey, blockDeviceMappingS
 		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 			Name:      machine.Name,
 			Namespace: machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "error describing AMI",
 		})
 		klog.Errorf("Error describing AMI: %v", err)
 		return nil, fmt.Errorf("error describing AMI: %v", err)
@@ -383,7 +383,7 @@ func launchInstance(machine *machinev1beta1.Machine, machineProviderConfig *mach
 		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 			Name:      machine.Name,
 			Namespace: machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "error creating EC2 instance",
 		})
 		// we return InvalidMachineConfiguration for 4xx errors which by convention signal client misconfiguration
 		// https://tools.ietf.org/html/rfc2616#section-6.1.1

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -101,9 +101,9 @@ func (r *Reconciler) create() error {
 		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to update load balancers",
 		})
-		return fmt.Errorf("failed to updated update load balancers: %w", err)
+		return fmt.Errorf("failed to update load balancers: %w", err)
 	}
 
 	klog.Infof("Created Machine %v", r.machine.Name)
@@ -128,7 +128,7 @@ func (r *Reconciler) delete() error {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "error getting existing instances",
 		})
 		klog.Errorf("%s: error getting existing instances: %v", r.machine.Name, err)
 		return err
@@ -145,9 +145,9 @@ func (r *Reconciler) delete() error {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to remove instance from load balancers",
 		})
-		return fmt.Errorf("failed to updated update load balancers: %w", err)
+		return fmt.Errorf("failed to remove instance from load balancers: %w", err)
 	}
 
 	terminatingInstances, err := terminateInstances(r.awsClient, existingInstances)
@@ -155,7 +155,7 @@ func (r *Reconciler) delete() error {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to delete instances",
 		})
 		return fmt.Errorf("failed to delete instaces: %w", err)
 	}
@@ -189,7 +189,7 @@ func (r *Reconciler) update() error {
 		metrics.RegisterFailedInstanceUpdate(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "error getting existing instances",
 		})
 		klog.Errorf("%s: error getting existing instances: %v", r.machine.Name, err)
 		return err
@@ -242,9 +242,9 @@ func (r *Reconciler) update() error {
 			metrics.RegisterFailedInstanceUpdate(&metrics.MachineLabels{
 				Name:      r.machine.Name,
 				Namespace: r.machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "failed to update load balancers",
 			})
-			return fmt.Errorf("failed to updated update load balancers: %w", err)
+			return fmt.Errorf("failed to update load balancers: %w", err)
 		}
 	} else {
 		// Didn't find any running instances, just newest existing one.
@@ -281,7 +281,7 @@ func (r *Reconciler) exists() (bool, error) {
 		metrics.RegisterFailedInstanceUpdate(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "error getting existing instances",
 		})
 		klog.Errorf("%s: error getting existing instances: %v", r.machine.Name, err)
 		return false, err

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -846,7 +846,7 @@ func TestDelete(t *testing.T) {
 
 				return machine
 			},
-			expectedError: errors.New("failed to updated update load balancers: arn2: unauthorized"),
+			expectedError: errors.New("failed to remove instance from load balancers: arn2: unauthorized"),
 			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
 				mockCtrl := gomock.NewController(t)
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)


### PR DESCRIPTION
This PR removes the full error from the Reason field in RegisterFailedInstanceXXXX metrics, because it was causing the metric to have high/unbound cardinality. The full error is still logged, so this PR should not affect the ability to troubleshoot issues.