### PR TITLE
OCPBUGS-15255: Add terminated as a handled state so terminated instances don't get stuck

### DIFF
--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -614,6 +614,25 @@ func TestExists(t *testing.T) {
 				return mockAWSClient
 			},
 		},
+		{
+			name: "Successfully find terminated instance",
+			machine: func() *machinev1beta1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				return machine
+			},
+			existsResult:  false,
+			expectedError: nil,
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("test-ami", "test-id", ec2.InstanceStateNameTerminated, "1.1.1.1"), nil).AnyTimes()
+				return mockAWSClient
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -879,6 +898,24 @@ func TestDelete(t *testing.T) {
 				return mockAWSClient
 			},
 		},
+		{
+			name: "Does not try to delete an instance if it's already in a terminated state",
+			machine: func() *machinev1beta1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				return machine
+			},
+			expectedError: nil,
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("test-ami", "test-id", ec2.InstanceStateNameTerminated, "1.1.1.1"), nil).Times(1)
+				return mockAWSClient
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -984,29 +1021,16 @@ func TestGetMachineInstances(t *testing.T) {
 			awsClientFunc: func(ctrl *gomock.Controller) awsclient.Client {
 				mockAWSClient := mockaws.NewMockClient(ctrl)
 
-				first := mockAWSClient.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
+				mockAWSClient.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
 					InstanceIds: aws.StringSlice([]string{instanceID}),
 				}).Return(
 					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
 					nil,
 				).Times(1)
 
-				mockAWSClient.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
-					Filters: []*ec2.Filter{
-						{
-							Name:   awsTagFilter("Name"),
-							Values: aws.StringSlice([]string{machine.Name}),
-						},
-
-						clusterFilter(clusterID),
-					},
-				}).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
-					nil,
-				).Times(1).After(first)
-
 				return mockAWSClient
 			},
+			exists: true,
 		},
 	}
 

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -39,7 +39,8 @@ import (
 const upstreamMachineClusterIDLabel = "sigs.k8s.io/cluster-api-cluster"
 
 // existingInstanceStates returns the list of states an EC2 instance can be in
-// while being considered "existing", i.e. mostly anything but "Terminated".
+// while being considered "existing"
+// terminated is also handled so that an instance can't get stuck in terminated
 func existingInstanceStates() []*string {
 	return []*string{
 		aws.String(ec2.InstanceStateNameRunning),
@@ -47,6 +48,7 @@ func existingInstanceStates() []*string {
 		aws.String(ec2.InstanceStateNameStopped),
 		aws.String(ec2.InstanceStateNameStopping),
 		aws.String(ec2.InstanceStateNameShuttingDown),
+		aws.String(ec2.InstanceStateNameTerminated),
 	}
 }
 
@@ -68,7 +70,7 @@ func getStoppedInstances(machine *machinev1beta1.Machine, client awsclient.Clien
 	return getInstances(machine, client, stoppedInstanceStateFilter)
 }
 
-// getExistingInstances returns all instances not terminated
+// getExistingInstances returns all instances
 func getExistingInstances(machine *machinev1beta1.Machine, client awsclient.Client) ([]*ec2.Instance, error) {
 	return getInstances(machine, client, existingInstanceStates())
 }


### PR DESCRIPTION
This is a PR to add terminated as a handled state, so if AWS terminates instances before they are ready the instance should no longer get stuck. Creating it as a draft PR to get input/test my changes.