### PR TITLE
OCPBUGS-20266: update bad url endpoint termination handler test

### DIFF
--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -187,7 +187,9 @@ var _ = Describe("Handler Suite", func() {
 					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 				})
 			})
+		})
 
+		Context("when the termination endpoint is invalid", func() {
 			Context("and the poll URL cannot be reached", func() {
 				BeforeEach(func() {
 					nonReachable := "abc#1://localhost"

--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Handler Suite", func() {
 			var counter int32
 
 			BeforeEach(func() {
+				counter = 0
 				// Ensure the polling logic is excercised in tests
 				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
 					if atomic.LoadInt32(&counter) == 4 {
@@ -159,7 +160,11 @@ var _ = Describe("Handler Suite", func() {
 
 			Context("and the instance termination notice is not fulfilled", func() {
 				BeforeEach(func() {
-					httpHandler = newMockHTTPHandler(notFoundFunc)
+					// we need to wrap the notFoundFunc so that we obey the counting mechanism of the polling tests
+					httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+						atomic.AddInt32(&counter, 1)
+						notFoundFunc(rw, req)
+					})
 				})
 
 				It("should not mark the node for deletion", func() {


### PR DESCRIPTION
This change moves the bad url test to its own `Context` block so that it does not get caught in the mock termination service counter. In some cases it is possible for the bad url test to be run first, when this happens the counter will never advance because the url is not valid. This produces a dead lock condition in the test. Migrating the test to its own block alleviates this issue.

This change also updates the "not fulfilled" test to ensure that the counter is updated when the http handler is replaced.