### PR TITLE
OCPCLOUD-2139: Use MAO module to work with scale from zero annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.28.0
 	github.com/openshift/api v0.0.0-20231019121755-0c5924392281
-	github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7
+	github.com/openshift/machine-api-operator v0.2.1-0.20231107142306-efda8d50967a
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
-github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -260,8 +258,8 @@ github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6 h1:3wgEtuYbZ76
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6/go.mod h1:Fkn7VRruQ4KwNGeaUmi9QgqLk/d7U6cj+UiP8b+0hiQ=
 github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7 h1:pJLcCSJzdiWCaJ4bAepgnvwMdP33LumbVJyWSW7+3ng=
 github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7/go.mod h1:jgxNp8aApJnZtECid9SUSr5Bu6DLo8Hfdv1DgFZaYA8=
-github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7 h1:6/Yok3qh3FPnjw+OsefCEPbV0KFEVkr00NaEYDpAY6M=
-github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7/go.mod h1:cYJjVQyNskmxEixGczlLytGF9iacFubTD/UbGvu5EEY=
+github.com/openshift/machine-api-operator v0.2.1-0.20231107142306-efda8d50967a h1:ov/zHouUnNMn2M6pqCfrYB/0tDGtHn/UlxdF3wGSmoI=
+github.com/openshift/machine-api-operator v0.2.1-0.20231107142306-efda8d50967a/go.mod h1:xZbFC5VJvaHo2vtUvwxloAqhbPMEgEhQU5R/YofIhHA=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -672,7 +670,6 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/actuators/machineset/controller.go
+++ b/pkg/actuators/machineset/controller.go
@@ -9,6 +9,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/openshift/machine-api-operator/pkg/util"
+	annotationsutil "github.com/openshift/machine-api-operator/pkg/util/machineset"
 	utils "github.com/openshift/machine-api-provider-aws/pkg/actuators/machine"
 	awsclient "github.com/openshift/machine-api-provider-aws/pkg/client"
 	corev1 "k8s.io/api/core/v1"
@@ -22,12 +23,6 @@ import (
 )
 
 const (
-	// This exposes compute information based on the providerSpec input.
-	// This is needed by the autoscaler to foresee upcoming capacity when scaling from zero.
-	// https://github.com/openshift/enhancements/pull/186
-	cpuKey    = "machine.openshift.io/vCPU"
-	memoryKey = "machine.openshift.io/memoryMb"
-	gpuKey    = "machine.openshift.io/GPU"
 	labelsKey = "capacity.cluster-autoscaler.kubernetes.io/labels"
 )
 
@@ -131,7 +126,7 @@ func (r *Reconciler) reconcile(machineSet *machinev1beta1.MachineSet) (ctrl.Resu
 	instanceType, err := r.InstanceTypesCache.GetInstanceType(awsClient, providerConfig.Placement.Region, providerConfig.InstanceType)
 	if err != nil {
 		klog.Errorf("Unable to set scale from zero annotations: unknown instance type %s: %v", providerConfig.InstanceType, err)
-		klog.Errorf("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
+		klog.Errorf("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{annotationsutil.CpuKey, annotationsutil.MemoryKey, annotationsutil.GpuCountKey})
 
 		// Returning no error to prevent further reconciliation, as user intervention is now required but emit an informational event
 		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedUpdate", "Failed to set autoscaling from zero annotations, instance type unknown")
@@ -142,10 +137,12 @@ func (r *Reconciler) reconcile(machineSet *machinev1beta1.MachineSet) (ctrl.Resu
 		machineSet.Annotations = make(map[string]string)
 	}
 
-	// TODO: get annotations keys from machine API
-	machineSet.Annotations[cpuKey] = strconv.FormatInt(instanceType.VCPU, 10)
-	machineSet.Annotations[memoryKey] = strconv.FormatInt(instanceType.MemoryMb, 10)
-	machineSet.Annotations[gpuKey] = strconv.FormatInt(instanceType.GPU, 10)
+	machineSet.Annotations = annotationsutil.SetCpuAnnotation(machineSet.Annotations, strconv.FormatInt(instanceType.VCPU, 10))
+	machineSet.Annotations = annotationsutil.SetMemoryAnnotation(machineSet.Annotations, strconv.FormatInt(instanceType.MemoryMb, 10))
+	machineSet.Annotations = annotationsutil.SetGpuCountAnnotation(machineSet.Annotations, strconv.FormatInt(instanceType.GPU, 10))
+	// TODO: We currently only support nvidia as GPU type. Once proper GPU types are introduced, we
+	// can pass the value in the second argument of the function SetGpuTypeAnnotation.
+	machineSet.Annotations = annotationsutil.SetGpuTypeAnnotation(machineSet.Annotations, annotationsutil.GpuNvidiaType)
 	// We guarantee that any existing labels provided via the capacity annotations are preserved.
 	// See https://github.com/kubernetes/autoscaler/pull/5382 and https://github.com/kubernetes/autoscaler/pull/5697
 	machineSet.Annotations[labelsKey] = util.MergeCommaSeparatedKeyValuePairs(

--- a/pkg/actuators/machineset/controller_test.go
+++ b/pkg/actuators/machineset/controller_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	gtypes "github.com/onsi/gomega/types"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	util "github.com/openshift/machine-api-operator/pkg/util/machineset"
 	awsclient "github.com/openshift/machine-api-provider-aws/pkg/client"
 	fakeawsclient "github.com/openshift/machine-api-provider-aws/pkg/client/fake"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -46,7 +46,7 @@ var _ = Describe("MachineSetReconciler", func() {
 	var namespace *corev1.Namespace
 	fakeClient, err := fakeawsclient.NewClient(nil, "", "", "")
 	Expect(err).ToNot(HaveOccurred())
-	awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
+	awsClientBuilder := func(client client.Client, secretName, namespace, region string, configManagedClient client.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 		return fakeClient, nil
 	}
 
@@ -128,10 +128,11 @@ var _ = Describe("MachineSetReconciler", func() {
 			instanceType:        "a1.2xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "8",
-				memoryKey: "16384",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "8",
+				util.MemoryKey:   "16384",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -139,10 +140,11 @@ var _ = Describe("MachineSetReconciler", func() {
 			instanceType:        "p2.16xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "64",
-				memoryKey: "749568",
-				gpuKey:    "16",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "64",
+				util.MemoryKey:   "749568",
+				util.GpuCountKey: "16",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -153,12 +155,13 @@ var _ = Describe("MachineSetReconciler", func() {
 				"annother": "existingAnnotation",
 			},
 			expectedAnnotations: map[string]string{
-				"existing": "annotation",
-				"annother": "existingAnnotation",
-				cpuKey:     "8",
-				memoryKey:  "16384",
-				gpuKey:     "0",
-				labelsKey:  "kubernetes.io/arch=amd64",
+				"existing":       "annotation",
+				"annother":       "existingAnnotation",
+				util.CpuKey:      "8",
+				util.MemoryKey:   "16384",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -166,10 +169,11 @@ var _ = Describe("MachineSetReconciler", func() {
 			instanceType:        "m6g.4xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "16",
-				memoryKey: "65536",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=arm64",
+				util.CpuKey:      "16",
+				util.MemoryKey:   "65536",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=arm64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -177,10 +181,11 @@ var _ = Describe("MachineSetReconciler", func() {
 			instanceType:        "m6i.8xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "32",
-				memoryKey: "131072",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "32",
+				util.MemoryKey:   "131072",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -188,10 +193,11 @@ var _ = Describe("MachineSetReconciler", func() {
 			instanceType:        "m6h.8xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "32",
-				memoryKey: "131072",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "32",
+				util.MemoryKey:   "131072",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -260,10 +266,11 @@ func TestReconcile(t *testing.T) {
 			instanceType:        "a1.2xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "8",
-				memoryKey: "16384",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "8",
+				util.MemoryKey:   "16384",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -272,10 +279,11 @@ func TestReconcile(t *testing.T) {
 			instanceType:        "p2.16xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "64",
-				memoryKey: "749568",
-				gpuKey:    "16",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "64",
+				util.MemoryKey:   "749568",
+				util.GpuCountKey: "16",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -287,12 +295,13 @@ func TestReconcile(t *testing.T) {
 				"annother": "existingAnnotation",
 			},
 			expectedAnnotations: map[string]string{
-				"existing": "annotation",
-				"annother": "existingAnnotation",
-				cpuKey:     "8",
-				memoryKey:  "16384",
-				gpuKey:     "0",
-				labelsKey:  "kubernetes.io/arch=amd64",
+				"existing":       "annotation",
+				"annother":       "existingAnnotation",
+				util.CpuKey:      "8",
+				util.MemoryKey:   "16384",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -315,10 +324,11 @@ func TestReconcile(t *testing.T) {
 			instanceType:        "m6g.4xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "16",
-				memoryKey: "65536",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=arm64",
+				util.CpuKey:      "16",
+				util.MemoryKey:   "65536",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=arm64",
 			},
 			expectErr: false,
 		},
@@ -327,10 +337,11 @@ func TestReconcile(t *testing.T) {
 			instanceType:        "m6i.8xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "32",
-				memoryKey: "131072",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "32",
+				util.MemoryKey:   "131072",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -339,10 +350,11 @@ func TestReconcile(t *testing.T) {
 			instanceType:        "m6h.8xlarge",
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
-				cpuKey:    "32",
-				memoryKey: "131072",
-				gpuKey:    "0",
-				labelsKey: "kubernetes.io/arch=amd64",
+				util.CpuKey:      "32",
+				util.MemoryKey:   "131072",
+				util.GpuCountKey: "0",
+				util.GpuTypeKey:  util.GpuNvidiaType,
+				labelsKey:        "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -357,7 +369,7 @@ func TestReconcile(t *testing.T) {
 
 			fakeClient, err := fakeawsclient.NewClient(nil, "", "", "")
 			Expect(err).ToNot(HaveOccurred())
-			awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
+			awsClientBuilder := func(client client.Client, secretName, namespace, region string, configManagedClient client.Client, regionCache awsclient.RegionCache) (awsclient.Client, error) {
 				return fakeClient, nil
 			}
 

--- a/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -271,7 +271,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 			"Failed to check if machine exists: %v", err,
 		))
 
-		if patchErr := r.updateStatus(ctx, m, pointer.StringDeref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+		if patchErr := r.updateStatus(ctx, m, ptr.Deref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 			klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 		}
 
@@ -283,7 +283,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		if err := r.actuator.Update(ctx, m); err != nil {
 			klog.Errorf("%v: error updating machine: %v, retrying in %v seconds", machineName, err, requeueAfter)
 
-			if patchErr := r.updateStatus(ctx, m, pointer.StringDeref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+			if patchErr := r.updateStatus(ctx, m, ptr.Deref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 				klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 			}
 
@@ -295,7 +295,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 		if !machineIsProvisioned(m) {
 			klog.Errorf("%v: instance exists but providerID or addresses has not been given to the machine yet, requeuing", machineName)
-			if patchErr := r.updateStatus(ctx, m, pointer.StringDeref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+			if patchErr := r.updateStatus(ctx, m, ptr.Deref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 				klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 			}
 
@@ -338,7 +338,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 	))
 
 	// Machine resource created and instance does not exist yet.
-	if pointer.StringDeref(m.Status.Phase, "") == "" {
+	if ptr.Deref(m.Status.Phase, "") == "" {
 		klog.V(2).Infof("%v: setting phase to Provisioning and requeuing", machineName)
 		if err := r.updateStatus(ctx, m, machinev1.PhaseProvisioning, nil, originalConditions); err != nil {
 			return reconcile.Result{}, err
@@ -400,7 +400,7 @@ func isInvalidMachineConfigurationError(err error) bool {
 // machine conditions so that the diff can be calculated properly within this function.
 func (r *ReconcileMachine) updateStatus(ctx context.Context, machine *machinev1.Machine, phase string, failureCause error, originalConditions []machinev1.Condition) error {
 	phaseChanged := false
-	if pointer.StringDeref(machine.Status.Phase, "") != phase {
+	if ptr.Deref(machine.Status.Phase, "") != phase {
 		klog.V(3).Infof("%v: going into phase %q", machine.GetName(), phase)
 
 		phaseChanged = true
@@ -582,7 +582,7 @@ func (r *ReconcileMachine) now() time.Time {
 }
 
 func machineIsProvisioned(machine *machinev1.Machine) bool {
-	return len(machine.Status.Addresses) > 0 || pointer.StringDeref(machine.Spec.ProviderID, "") != ""
+	return len(machine.Status.Addresses) > 0 || ptr.Deref(machine.Spec.ProviderID, "") != ""
 }
 
 func machineHasNode(machine *machinev1.Machine) bool {
@@ -590,7 +590,7 @@ func machineHasNode(machine *machinev1.Machine) bool {
 }
 
 func machineIsFailed(machine *machinev1.Machine) bool {
-	return pointer.StringDeref(machine.Status.Phase, "") == machinev1.PhaseFailed
+	return ptr.Deref(machine.Status.Phase, "") == machinev1.PhaseFailed
 }
 
 func nodeIsUnreachable(node *corev1.Node) bool {

--- a/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/drain_controller.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/drain_controller.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/drain"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -79,7 +79,7 @@ func (d *machineDrainController) Reconcile(ctx context.Context, request reconcil
 	existingDrainedCondition := conditions.Get(m, machinev1.MachineDrained)
 	alreadyDrained := existingDrainedCondition != nil && existingDrainedCondition.Status == corev1.ConditionTrue
 
-	if !m.ObjectMeta.DeletionTimestamp.IsZero() && pointer.StringDeref(m.Status.Phase, "") == machinev1.PhaseDeleting && !alreadyDrained {
+	if !m.ObjectMeta.DeletionTimestamp.IsZero() && ptr.Deref(m.Status.Phase, "") == machinev1.PhaseDeleting && !alreadyDrained {
 		drainFinishedCondition := conditions.TrueCondition(machinev1.MachineDrained)
 
 		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {

--- a/vendor/github.com/openshift/machine-api-operator/pkg/metrics/metrics.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/metrics/metrics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -136,7 +136,7 @@ func (mc MachineCollector) collectMachineMetrics(ch chan<- prometheus.Metric) {
 		}
 		// Only gather metrics for machines with a phase.  This indicates
 		// That the machine-controller is running on this cluster.
-		phase := pointer.StringDeref(machine.Status.Phase, "")
+		phase := ptr.Deref(machine.Status.Phase, "")
 		if phase != "" {
 			ch <- prometheus.MustNewConstMetric(
 				MachineInfoDesc,
@@ -144,7 +144,7 @@ func (mc MachineCollector) collectMachineMetrics(ch chan<- prometheus.Metric) {
 				float64(machine.ObjectMeta.GetCreationTimestamp().Time.Unix()),
 				machine.ObjectMeta.Name,
 				machine.ObjectMeta.Namespace,
-				pointer.StringDeref(machine.Spec.ProviderID, ""),
+				ptr.Deref(machine.Spec.ProviderID, ""),
 				nodeName,
 				machine.TypeMeta.APIVersion,
 				phase,

--- a/vendor/github.com/openshift/machine-api-operator/pkg/util/machineset/util.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/util/machineset/util.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"errors"
+)
+
+const (
+	// Deprecated OpenShift introduced annotations for scaling from zero.
+	CpuKeyDeprecated      = "machine.openshift.io/vCPU"
+	MemoryKeyDeprecated   = "machine.openshift.io/memoryMb"
+	GpuCountKeyDeprecated = "machine.openshift.io/GPU"
+	MaxPodsKeyDeprecated  = "machine.openshift.io/maxPods"
+
+	// Upstream preferred annotations for scaling from zero.
+	CpuKey      = "capacity.cluster-autoscaler.kubernetes.io/cpu"
+	MemoryKey   = "capacity.cluster-autoscaler.kubernetes.io/memory"
+	GpuTypeKey  = "capacity.cluster-autoscaler.kubernetes.io/gpu-type"
+	GpuCountKey = "capacity.cluster-autoscaler.kubernetes.io/gpu-count"
+	MaxPodsKey  = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
+
+	GpuNvidiaType = "nvidia.com/gpu"
+)
+
+// This module's intended use is to perform changes and basic checks
+// to scale from zero annotations on MachineSets. Example use of the module:
+//
+// ann := machineSet.Annotations
+// ann = SetCpuAnnotation(ann, 10)
+// ann = SetMemoryAnnotation(ann, 10)
+// if isScaleFromZeroAnnotations := HasScaleFromZeroAnnotationsEnabled(ann); !isScaleFromZeroAnnotations { ... }
+
+var (
+	// errAnnotationKeyNotFound signals to the user that the selected key was not found in the MachineSet's annotations
+	errAnnotationKeyNotFound = errors.New("could not find the selected annotation key in the MachineSet's annotations")
+)
+
+// ParseMachineSetAnnotationKey parses MachineSet's annotations and look for a key
+func ParseMachineSetAnnotationKey(annotations map[string]string, key string) (string, error) {
+	if val, exists := annotations[key]; exists && key != "" {
+		return val, nil
+	}
+
+	return "", errAnnotationKeyNotFound
+}
+
+// HasScaleFromZeroAnnotationsEnabled checks that cpu and memory upstream annotations are set in a MachineSet.
+func HasScaleFromZeroAnnotationsEnabled(annotations map[string]string) bool {
+	cpu := annotations[CpuKey]
+	mem := annotations[MemoryKey]
+
+	if cpu != "" && mem != "" {
+		return true
+	}
+	return false
+}
+
+// SetCpuAnnotation sets a value for a cpu key in the annotations of a MachineSet.
+func SetCpuAnnotation(annotations map[string]string, value string) map[string]string {
+	annotations[CpuKey] = value
+
+	return annotations
+}
+
+// SetMemoryAnnotation sets a value for a mempory key in the annotations of a MachineSet.
+func SetMemoryAnnotation(annotations map[string]string, value string) map[string]string {
+	annotations[MemoryKey] = value
+
+	return annotations
+}
+
+// SetGpuCountAnnotation sets a value for a gpu count key in the annotations of a MachineSet.
+func SetGpuCountAnnotation(annotations map[string]string, value string) map[string]string {
+	annotations[GpuCountKey] = value
+
+	return annotations
+}
+
+// SetGpuTypeAnnotation sets a value for gpu type in the annotations of a MachineSet.
+// Currently, we only support nvidia as a gpu type.
+func SetGpuTypeAnnotation(annotations map[string]string, _ string) map[string]string {
+	// TODO: Once we introduce proper gpu types, this needs to be changed.
+	annotations[GpuTypeKey] = GpuNvidiaType
+
+	return annotations
+}
+
+// SetMaxPodsAnnotation sets a value for a maxPods key in the annotations of a MachineSet.
+func SetMaxPodsAnnotation(annotations map[string]string, value string) map[string]string {
+	annotations[MaxPodsKey] = value
+
+	return annotations
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -282,12 +282,13 @@ github.com/openshift/client-go/machine/listers/machine/v1beta1
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/leaderelection
-# github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7
+# github.com/openshift/machine-api-operator v0.2.1-0.20231107142306-efda8d50967a
 ## explicit; go 1.19
 github.com/openshift/machine-api-operator/pkg/controller/machine
 github.com/openshift/machine-api-operator/pkg/metrics
 github.com/openshift/machine-api-operator/pkg/util
 github.com/openshift/machine-api-operator/pkg/util/conditions
+github.com/openshift/machine-api-operator/pkg/util/machineset
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 ## explicit
 github.com/peterbourgon/diskv


### PR DESCRIPTION
This PR changes the way we work with scale from zero annotations. We want to check/set the upstream version of these annotations.

This work is dependant on two other PRs:
- Introduce module to MAO: https://github.com/openshift/machine-api-operator/pull/1169
- CAO adds the upstream version of annotations: https://github.com/openshift/cluster-autoscaler-operator/pull/294

We currently expect CI to fail here. We need to merge the module to MAO first, from there on, we can import a new version of MAO into the provider repo.
