### PR TITLE
OCPBUGS-28325: add an extra vendor exclude to snyk config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - "vendor/**"
+    - "**/vendor/**"


### PR DESCRIPTION
this change is being added to pickup the vendor files that are appearing in the cachito expansion.