### PR TITLE
OCPBUGS-34255: Updating ose-machine-api-provider-aws-container image to be consistent with ART for 4.17

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-provider-aws
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-aws/bin/machine-controller-manager /
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-aws/bin/termination-handler /
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/machine-api-provider-aws
 
-go 1.21
+go 1.22
 
-toolchain go1.21.0
+toolchain go1.22.1
 
 require (
 	github.com/aws/aws-sdk-go v1.50.0


### PR DESCRIPTION
Extends #102 to attempt to fix the unit tests that were failing