### PR TITLE
OCPBUGS-44373: fix Associate*IpAddress flag when launch EC2

### DIFF
--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -1095,8 +1095,8 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
 						AssociateCarrierIpAddress: aws.Bool(true),
+						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
 						SubnetId:                  aws.String(stubSubnetID),
 						Groups:                    stubSecurityGroupsDefault,
 					},
@@ -1133,9 +1133,10 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex: aws.Int64(providerConfig.DeviceIndex),
-						SubnetId:    aws.String(stubSubnetID),
-						Groups:      stubSecurityGroupsDefault,
+						AssociateCarrierIpAddress: aws.Bool(false),
+						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
+						SubnetId:                  aws.String(stubSubnetID),
+						Groups:                    stubSecurityGroupsDefault,
 					},
 				},
 				UserData: aws.String(""),
@@ -1169,9 +1170,10 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex: aws.Int64(providerConfig.DeviceIndex),
-						SubnetId:    aws.String(stubSubnetID),
-						Groups:      stubSecurityGroupsDefault,
+						AssociatePublicIpAddress: aws.Bool(false),
+						DeviceIndex:              aws.Int64(providerConfig.DeviceIndex),
+						SubnetId:                 aws.String(stubSubnetID),
+						Groups:                   stubSecurityGroupsDefault,
 					},
 				},
 				UserData: aws.String(""),


### PR DESCRIPTION
This PR enforces the public IP assignment attribute* to be always set
when `publicIp` is set in the machine object. This behavior has been
changed in https://github.com/openshift/machine-api-provider-aws/pull/78 when the Wavelength zone support was added,
requiring an different attribute to assign public IP on launch
from a carrier infrastructure.

*attibute mutually exclusive required to assign public IP to an EC2
instance on launch by zone type:
- availability-zone: AssociatePublicIpAddress
- local-zone: AssociatePublicIpAddress
- wavelength-zone: AssociateCarrierIpAddress