### PR TITLE
[release-4.16] OCPBUGS-46508: fix Associate*IpAddress flag on launch EC2

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -21,6 +21,10 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	zoneTypeWavelengthZone = "wavelength-zone"
+)
+
 // Scan machine tags, and return a deduped tags list. The first found value gets precedence.
 func removeDuplicatedTags(tags []*ec2.Tag) []*ec2.Tag {
 	m := make(map[string]bool)
@@ -367,10 +371,12 @@ func launchInstance(machine *machinev1beta1.Machine, machineProviderConfig *mach
 			Groups:      securityGroupsIDs,
 		},
 	}
-	// Public IP assignment is different in Wavelength Zones.
-	// AvailabilityZone and LocalZone uses InternetGateway.
-	// WavelengthZone uses Carrier Gateway.
-	if aws.BoolValue(machineProviderConfig.PublicIP) {
+
+	// Public IP address assignment to instances created in Wavelength
+	// Zones' subnet requires the attribute AssociateCarrierIpAddress
+	// instead of AssociatePublicIpAddress.
+	// AssociatePublicIpAddress and AssociateCarrierIpAddress are mutually exclusive.
+	if machineProviderConfig.PublicIP != nil {
 		zoneName, err := getAvalabilityZoneFromSubnetID(*subnetID, awsClient)
 		if err != nil {
 			return nil, mapierrors.InvalidMachineConfiguration("error discoverying zone type: %v", err)
@@ -380,7 +386,7 @@ func launchInstance(machine *machinev1beta1.Machine, machineProviderConfig *mach
 			return nil, mapierrors.InvalidMachineConfiguration("error discoverying zone type: %v", err)
 		}
 
-		if zoneType == "wavelength-zone" {
+		if zoneType == zoneTypeWavelengthZone {
 			networkInterfaces[0].AssociateCarrierIpAddress = machineProviderConfig.PublicIP
 		} else {
 			networkInterfaces[0].AssociatePublicIpAddress = machineProviderConfig.PublicIP

--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -1058,8 +1058,8 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
 						AssociateCarrierIpAddress: aws.Bool(true),
+						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
 						SubnetId:                  aws.String(stubSubnetID),
 						Groups:                    stubSecurityGroupsDefault,
 					},
@@ -1096,9 +1096,10 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex: aws.Int64(providerConfig.DeviceIndex),
-						SubnetId:    aws.String(stubSubnetID),
-						Groups:      stubSecurityGroupsDefault,
+						AssociateCarrierIpAddress: aws.Bool(false),
+						DeviceIndex:               aws.Int64(providerConfig.DeviceIndex),
+						SubnetId:                  aws.String(stubSubnetID),
+						Groups:                    stubSecurityGroupsDefault,
 					},
 				},
 				UserData: aws.String(""),
@@ -1132,9 +1133,10 @@ func TestLaunchInstance(t *testing.T) {
 				}},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					{
-						DeviceIndex: aws.Int64(providerConfig.DeviceIndex),
-						SubnetId:    aws.String(stubSubnetID),
-						Groups:      stubSecurityGroupsDefault,
+						AssociatePublicIpAddress: aws.Bool(false),
+						DeviceIndex:              aws.Int64(providerConfig.DeviceIndex),
+						SubnetId:                 aws.String(stubSubnetID),
+						Groups:                   stubSecurityGroupsDefault,
 					},
 				},
 				UserData: aws.String(""),


### PR DESCRIPTION
This PR enforces the public IP assignment attribute* to be always set when `publicIp` is set in the machine object. This behavior has been changed in #78 when the Wavelength zone support was added, requiring an different attribute to assign public IP on launch from a carrier infrastructure.

*attibute mutually exclusive required to assign public IP to an EC2 instance on launch by zone type:
- availability-zone: AssociatePublicIpAddress
- local-zone: AssociatePublicIpAddress
- wavelength-zone: AssociateCarrierIpAddress