### PR TITLE
[release-4.19] OCPBUGS-52454: Add spotMarketRequest on marketType spot

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -577,6 +577,10 @@ func getInstanceMarketOptionsRequest(providerConfig *machinev1beta1.AWSMachinePr
 		return nil, errors.New("can't create spot capacity-blocks, remove spot market request")
 	}
 
+	if (providerConfig.MarketType == machinev1beta1.MarketTypeSpot || providerConfig.SpotMarketOptions != nil) && providerConfig.CapacityReservationID != "" {
+		return nil, errors.New("unable to generate marketOptions for spot instance, capacityReservationID is incompatible with marketType spot and spotMarketOptions")
+	}
+
 	// Infer MarketType if not explicitly set
 	if providerConfig.SpotMarketOptions != nil && providerConfig.MarketType == "" {
 		providerConfig.MarketType = machinev1beta1.MarketTypeSpot
@@ -584,6 +588,10 @@ func getInstanceMarketOptionsRequest(providerConfig *machinev1beta1.AWSMachinePr
 
 	if providerConfig.MarketType == "" {
 		providerConfig.MarketType = machinev1beta1.MarketTypeOnDemand
+	}
+
+	if providerConfig.MarketType == machinev1beta1.MarketTypeSpot && providerConfig.SpotMarketOptions == nil {
+		providerConfig.SpotMarketOptions = &machinev1beta1.SpotMarketOptions{}
 	}
 
 	switch providerConfig.MarketType {

--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -1255,6 +1255,38 @@ func TestGetInstanceMarketOptionsRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "with an marketType Spot options specified",
+			providerConfig: &machinev1beta1.AWSMachineProviderConfig{
+				MarketType: machinev1beta1.MarketTypeSpot,
+			},
+			expectedRequest: &ec2.InstanceMarketOptionsRequest{
+				MarketType: aws.String(ec2.MarketTypeSpot),
+				SpotOptions: &ec2.SpotMarketOptions{
+					InstanceInterruptionBehavior: aws.String(ec2.InstanceInterruptionBehaviorTerminate),
+					SpotInstanceType:             aws.String(ec2.SpotInstanceTypeOneTime),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with an marketType Spot and CapacityRerservationID specified",
+			providerConfig: &machinev1beta1.AWSMachineProviderConfig{
+				MarketType:            machinev1beta1.MarketTypeSpot,
+				CapacityReservationID: mockCapacityReservationID,
+			},
+			expectedRequest: nil,
+			wantErr:         true,
+		},
+		{
+			name: "with an marketType Spot and CapacityRerservationID specified",
+			providerConfig: &machinev1beta1.AWSMachineProviderConfig{
+				SpotMarketOptions:     &machinev1beta1.SpotMarketOptions{},
+				CapacityReservationID: mockCapacityReservationID,
+			},
+			expectedRequest: nil,
+			wantErr:         true,
+		},
+		{
 			name: "with an empty MaxPrice specified",
 			providerConfig: &machinev1beta1.AWSMachineProviderConfig{
 				SpotMarketOptions: &machinev1beta1.SpotMarketOptions{


### PR DESCRIPTION
If only MarketType=Spot is specified but spotMarketType is not provided, then we must explicitly add spotMarketType to the API config.