### PR TITLE
OCPBUGS-56487: fix: make machineset annotation controller respect paused condition

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -212,6 +212,7 @@ func main() {
 		RegionCache:         describeRegionsCache,
 		ConfigManagedClient: configManagedClient,
 		InstanceTypesCache:  machinesetcontroller.NewInstanceTypesCache(),
+		Gate:                defaultMutableGate,
 	}).SetupWithManager(mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
 		os.Exit(1)


### PR DESCRIPTION
This was missed when https://github.com/openshift/machine-api-operator/pull/1287 was added.

The machineset annotation controller must respect the paused condition for a MachineSet.

Context: https://redhat-internal.slack.com/archives/GE2HQ9QP4/p1747830982876869