### PR TITLE
OCPBUGS-83873: Changed timeout for node ready logic in OTE

### DIFF
--- a/openshift-tests/test/e2e/dedicated_hosts.go
+++ b/openshift-tests/test/e2e/dedicated_hosts.go
@@ -488,9 +488,12 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:AWSDedicatedHosts][plat
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdMachine).NotTo(BeNil())
 
-			// Register cleanup immediately after successful creation
+			cleanupComplete := false
+			// Register cleanup immediately after successful creation in case test fails before the manual cleanup
 			DeferCleanup(func() {
-				cleanupMachineAndNode(ctx, kubeConfig, kubeClient, machineName)
+				if !cleanupComplete {
+					cleanupMachineAndNode(ctx, kubeConfig, kubeClient, machineName)
+				}
 			})
 
 			var dynamicHostID string
@@ -534,6 +537,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:AWSDedicatedHosts][plat
 
 			// Manually trigger cleanup before verifying host release
 			cleanupMachineAndNode(ctx, kubeConfig, kubeClient, machineName)
+			cleanupComplete = true
 
 			By("Verifying dynamically allocated host is released after cleanup")
 			GinkgoWriter.Printf("Verifying dynamically allocated host %s is released after cleanup\n", dynamicHostID)
@@ -937,7 +941,7 @@ func cleanupMachineAndNode(ctx context.Context, kubeConfig *rest.Config, kubeCli
 				return true
 			}
 			return false
-		}, 2*time.Minute, defaultPollingInterval).Should(BeTrue())
+		}, 5*time.Minute, defaultPollingInterval).Should(BeTrue())
 	}
 
 	// Delete the machine


### PR DESCRIPTION
OCPBUGS-83873

### Changes
- Changed timeout for node ready logic to 5 minutes (from 2)
- Added flag to cleanup complete so we do not attempt twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential duplicate cleanup execution in dedicated host tests by implementing proper cleanup state tracking.
  * Increased timeout for node registration detection to improve test reliability and reduce intermittent failures.

* **Tests**
  * Enhanced test robustness with improved cleanup handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->