### PR TITLE
NO-ISSUE: Add opt-in pprof endpoint to machine-controller-manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	_ "net/http/pprof"
 	"os"
 	"strings"
 	"time"
@@ -95,6 +96,18 @@ func main() {
 		"health-addr",
 		":9440",
 		"The address for health checking.",
+	)
+
+	enablePprof := flag.Bool(
+		"enable-pprof",
+		false,
+		"Enable the pprof profiling endpoint.",
+	)
+
+	pprofAddr := flag.String(
+		"pprof-bind-address",
+		"127.0.0.1:6060",
+		"The address for serving pprof profiling endpoints (requires --enable-pprof).",
 	)
 
 	// Sets up feature gates (version from build time, default 4 for unknown)
@@ -229,6 +242,14 @@ func main() {
 
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		klog.Fatal(err)
+	}
+
+	if *enablePprof {
+		if err := mgr.Add(&pprofServer{
+			Addr: *pprofAddr,
+		}); err != nil {
+			klog.Fatalf("Error adding pprof server: %v", err)
+		}
 	}
 
 	// Start the Cmd

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestPprofServerResponds(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := &pprofServer{
+		Addr: addr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start(ctx)
+	}()
+
+	var resp *http.Response
+	for i := 0; i < 20; i++ {
+		resp, err = http.Get(fmt.Sprintf("http://%s/debug/pprof/", addr))
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("pprof server did not respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("server returned error on shutdown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("server did not shut down within 10 seconds")
+	}
+}
+
+func TestPprofServerGracefulShutdown(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := &pprofServer{
+		Addr: addr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start(ctx)
+	}()
+
+	for i := 0; i < 20; i++ {
+		resp, getErr := http.Get(fmt.Sprintf("http://%s/debug/pprof/", addr))
+		if getErr == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("server returned error on shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down within 5 seconds")
+	}
+}
+
+func TestPprofServerNeedLeaderElection(t *testing.T) {
+	srv := &pprofServer{}
+	if srv.NeedLeaderElection() {
+		t.Error("pprofServer.NeedLeaderElection() returned true, expected false")
+	}
+}

--- a/cmd/manager/pprof.go
+++ b/cmd/manager/pprof.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+type pprofServer struct {
+	Addr string
+}
+
+func (s *pprofServer) Start(ctx context.Context) error {
+	srv := &http.Server{
+		Addr:    s.Addr,
+		Handler: http.DefaultServeMux,
+	}
+	klog.Infof("Starting pprof server on %s", s.Addr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("pprof server failed: %w", err)
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return srv.Shutdown(shutdownCtx)
+}
+
+func (s *pprofServer) NeedLeaderElection() bool {
+	return false
+}


### PR DESCRIPTION
## Description

Add an opt-in pprof profiling endpoint to the AWS machine controller manager, gated behind the `--enable-pprof` flag (default: disabled).

The pprof server listens on **plaintext HTTP** at `127.0.0.1:6060` (loopback only). TLS termination and authentication are expected to be handled by a **kube-rbac-proxy sidecar** configured in the `machine-api-operator` deployment, consistent with how other serving endpoints are secured across machine-api controllers.

### Changes

- **`cmd/manager/pprof.go`** — `pprofServer` runnable that serves `net/http/pprof` handlers via the manager lifecycle with graceful shutdown on context cancellation.
- **`cmd/manager/main.go`** — `--enable-pprof` and `--pprof-bind-address` CLI flags. When enabled, registers the pprof server as a manager runnable (no leader election required).
- **`cmd/manager/main_test.go`** — unit tests for server response, graceful shutdown, and leader election opt-out.

### Dependencies

- Requires a corresponding change in `machine-api-operator` to inject a kube-rbac-proxy sidecar for the pprof port in the `machine-api-controllers` deployment (AWS only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional profiling support with CLI configuration flags: `--enable-pprof` to activate profiling and `--pprof-bind-address` to specify the listen address (default: `127.0.0.1:6060`).

* **Tests**
  * Added integration tests for profiling server startup, graceful shutdown, and leader-election behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->