### PR TITLE
NO-JIRA: Cache region validation response and close AWS sessions

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -91,6 +91,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1beta1.Machine) 
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
 		return a.handleMachineError(machine, fmtErr, createEventAction)
 	}
+	defer scope.Close()
 	if err := newReconciler(scope).create(); err != nil {
 		if err := scope.patchMachine(); err != nil {
 			return err
@@ -117,6 +118,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1beta1.Machine) 
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.GetName(), err)
 	}
+	defer scope.Close()
 	return newReconciler(scope).exists()
 }
 
@@ -135,6 +137,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1beta1.Machine) 
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
 		return a.handleMachineError(machine, fmtErr, updateEventAction)
 	}
+	defer scope.Close()
 	if err := newReconciler(scope).update(); err != nil {
 		// Update machine and machine status in case it was modified
 		if err := scope.patchMachine(); err != nil {
@@ -175,6 +178,7 @@ func (a *Actuator) Delete(ctx context.Context, machine *machinev1beta1.Machine) 
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
 		return a.handleMachineError(machine, fmtErr, deleteEventAction)
 	}
+	defer scope.Close()
 	if err := newReconciler(scope).delete(); err != nil {
 		if err := scope.patchMachine(); err != nil {
 			return err

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -37,6 +37,10 @@ type machineScopeParams struct {
 	regionCache awsclient.RegionCache
 }
 
+type idleCloser interface {
+	CloseIdleConnections()
+}
+
 type machineScope struct {
 	context.Context
 
@@ -83,6 +87,12 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		providerSpec:       providerSpec,
 		providerStatus:     providerStatus,
 	}, nil
+}
+
+func (s *machineScope) Close() {
+	if c, ok := s.awsClient.(idleCloser); ok {
+		c.CloseIdleConnections()
+	}
 }
 
 // Patch patches the machine spec and machine status after reconciling.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -254,6 +254,7 @@ func NewClientFromKeys(accessKey, secretAccessKey, region string) (Client, error
 type DescribeRegionsData struct {
 	err                   error
 	describeRegionsOutput *ec2.DescribeRegionsOutput
+	validatedRegions      map[string]bool
 	lastUpdated           time.Time
 }
 
@@ -262,9 +263,11 @@ type regionCache struct {
 	mutex sync.RWMutex
 }
 
-// RegionCache caches successful DescribeRegions API calls.
+// RegionCache caches successful DescribeRegions API calls and region validation results.
 type RegionCache interface {
 	GetCachedDescribeRegions(awsSession *session.Session) (*ec2.DescribeRegionsOutput, error)
+	IsRegionValidated(awsSession *session.Session, region string) (bool, error)
+	SetRegionValidated(awsSession *session.Session, region string) error
 }
 
 // NewRegionCache creates a new empty DescribeRegionsData cache with lock.
@@ -312,6 +315,44 @@ func (c *regionCache) GetCachedDescribeRegions(awsSession *session.Session) (*ec
 	return describeRegionsOutput, nil
 }
 
+func (c *regionCache) IsRegionValidated(awsSession *session.Session, region string) (bool, error) {
+	creds, err := awsSession.Config.Credentials.Get()
+	if err != nil {
+		return false, err
+	}
+
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	regionData := c.data[creds.AccessKeyID]
+	if regionData.validatedRegions != nil &&
+		regionData.validatedRegions[region] &&
+		time.Since(regionData.lastUpdated) < awsRegionsCacheExpirationDuration {
+		klog.V(4).Infof("Region %s validation cached, skipping endpoint check", region)
+		return true, nil
+	}
+	return false, nil
+}
+
+func (c *regionCache) SetRegionValidated(awsSession *session.Session, region string) error {
+	creds, err := awsSession.Config.Credentials.Get()
+	if err != nil {
+		return err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	regionData := c.data[creds.AccessKeyID]
+	if regionData.validatedRegions == nil {
+		regionData.validatedRegions = make(map[string]bool)
+	}
+	regionData.validatedRegions[region] = true
+	if regionData.lastUpdated.IsZero() {
+		regionData.lastUpdated = time.Now()
+	}
+	c.data[creds.AccessKeyID] = regionData
+	return nil
+}
+
 // Check that region is in the DescribeRegions list and is opted in.
 func validateRegion(describeRegionsOutput *ec2.DescribeRegionsOutput, region string) (*ec2.Region, error) {
 	var regionData *ec2.Region
@@ -341,31 +382,41 @@ func NewValidatedClient(ctrlRuntimeClient client.Client, secretName, namespace, 
 		return nil, err
 	}
 
-	// Check that the endpoint can be resolved by the endpoint resolver.
-	// If the endpoint is not resolvable locally, we try to validate using the AWS API.
-	// If the endpoint is not known, it is not a standard or configured custom region.
-	// In that case, the client will likely not be able to connect
-	_, err = s.Config.EndpointResolver.EndpointFor("ec2", region, func(opts *endpoints.Options) {
-		opts.StrictMatching = true
-	})
+	validated, err := regionCache.IsRegionValidated(s, region)
 	if err != nil {
-		switch err.(type) {
-		case endpoints.UnknownEndpointError:
-			klog.Infof("Region %s is not recognized by aws-sdk, trying to validate using API", region)
-			var describeRegionsOutput *ec2.DescribeRegionsOutput
-			describeRegionsOutput, err = regionCache.GetCachedDescribeRegions(s)
-			if err != nil {
-				return nil, fmt.Errorf("could not retrieve region data: %w", err)
-			}
+		return nil, fmt.Errorf("could not check region validation cache: %w", err)
+	}
 
-			_, err = validateRegion(describeRegionsOutput, region)
-			if err != nil {
-				return nil, err
+	if !validated {
+		// Check that the endpoint can be resolved by the endpoint resolver.
+		// If the endpoint is not resolvable locally, we try to validate using the AWS API.
+		// If the endpoint is not known, it is not a standard or configured custom region.
+		// In that case, the client will likely not be able to connect
+		_, err = s.Config.EndpointResolver.EndpointFor("ec2", region, func(opts *endpoints.Options) {
+			opts.StrictMatching = true
+		})
+		if err != nil {
+			switch err.(type) {
+			case endpoints.UnknownEndpointError:
+				klog.Infof("Region %s is not recognized by aws-sdk, trying to validate using API", region)
+				var describeRegionsOutput *ec2.DescribeRegionsOutput
+				describeRegionsOutput, err = regionCache.GetCachedDescribeRegions(s)
+				if err != nil {
+					return nil, fmt.Errorf("could not retrieve region data: %w", err)
+				}
+
+				_, err = validateRegion(describeRegionsOutput, region)
+				if err != nil {
+					return nil, err
+				}
+				klog.V(4).Infof("Region %s validated via API, caching result", region)
+				if cacheErr := regionCache.SetRegionValidated(s, region); cacheErr != nil {
+					klog.V(4).Infof("Failed to cache region validation for %s: %v", region, cacheErr)
+				}
+			default:
+				return nil, fmt.Errorf("region %q not resolved: %w", region, err)
 			}
 		}
-	}
-	if err != nil {
-		return nil, fmt.Errorf("region %q not resolved: %w", region, err)
 	}
 
 	return &awsClient{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -110,6 +110,14 @@ type awsClient struct {
 	ec2Client   ec2iface.EC2API
 	elbClient   elbiface.ELBAPI
 	elbv2Client elbv2iface.ELBV2API
+	session     *session.Session
+}
+
+func (c *awsClient) CloseIdleConnections() {
+	if c.session != nil && c.session.Config.HTTPClient != nil {
+		c.session.Config.HTTPClient.CloseIdleConnections()
+		klog.V(4).Info("Closed AWS session idle connections")
+	}
 }
 
 func (c *awsClient) DescribeDHCPOptions(input *ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error) {
@@ -222,6 +230,7 @@ func NewClient(ctrlRuntimeClient client.Client, secretName, namespace, region st
 		ec2Client:   ec2.New(s),
 		elbClient:   elb.New(s),
 		elbv2Client: elbv2.New(s),
+		session:     s,
 	}, nil
 }
 
@@ -247,6 +256,7 @@ func NewClientFromKeys(accessKey, secretAccessKey, region string) (Client, error
 		ec2Client:   ec2.New(s),
 		elbClient:   elb.New(s),
 		elbv2Client: elbv2.New(s),
+		session:     s,
 	}, nil
 }
 
@@ -423,6 +433,7 @@ func NewValidatedClient(ctrlRuntimeClient client.Client, secretName, namespace, 
 		ec2Client:   ec2.New(s),
 		elbClient:   elb.New(s),
 		elbv2Client: elbv2.New(s),
+		session:     s,
 	}, nil
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,8 +2,12 @@ package client
 
 import (
 	"io/ioutil"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,5 +76,85 @@ func TestUseCustomCABundle(t *testing.T) {
 				t.Errorf("unexpected CA bundle: expected=%s; got %s", e, a)
 			}
 		})
+	}
+}
+
+func testSession(accessKeyID string) *session.Session {
+	return session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKeyID, "secret", "token"),
+		Region:      aws.String("us-east-1"),
+	}))
+}
+
+func TestRegionValidationCacheMiss(t *testing.T) {
+	cache := NewRegionCache()
+	sess := testSession("AKID-A")
+
+	validated, err := cache.IsRegionValidated(sess, "mx-central-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if validated {
+		t.Error("expected cache miss on first call, got hit")
+	}
+}
+
+func TestRegionValidationCacheHit(t *testing.T) {
+	cache := NewRegionCache()
+	sess := testSession("AKID-A")
+
+	if err := cache.SetRegionValidated(sess, "mx-central-1"); err != nil {
+		t.Fatalf("unexpected error from SetRegionValidated: %v", err)
+	}
+
+	validated, err := cache.IsRegionValidated(sess, "mx-central-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !validated {
+		t.Error("expected cache hit after SetRegionValidated, got miss")
+	}
+}
+
+func TestRegionValidationCacheExpiry(t *testing.T) {
+	c := &regionCache{
+		data:  map[string]DescribeRegionsData{},
+		mutex: sync.RWMutex{},
+	}
+	sess := testSession("AKID-A")
+
+	if err := c.SetRegionValidated(sess, "mx-central-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expire the cache entry
+	data := c.data["AKID-A"]
+	data.lastUpdated = time.Now().Add(-awsRegionsCacheExpirationDuration - time.Minute)
+	c.data["AKID-A"] = data
+
+	validated, err := c.IsRegionValidated(sess, "mx-central-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if validated {
+		t.Error("expected cache miss after expiry, got hit")
+	}
+}
+
+func TestRegionValidationCachePerCredentialIsolation(t *testing.T) {
+	cache := NewRegionCache()
+	sessA := testSession("AKID-A")
+	sessB := testSession("AKID-B")
+
+	if err := cache.SetRegionValidated(sessA, "mx-central-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	validated, err := cache.IsRegionValidated(sessB, "mx-central-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if validated {
+		t.Error("expected cache miss for different credentials, got hit")
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -157,4 +159,36 @@ func TestRegionValidationCachePerCredentialIsolation(t *testing.T) {
 	if validated {
 		t.Error("expected cache miss for different credentials, got hit")
 	}
+}
+
+type spyTransport struct {
+	closed bool
+}
+
+func (s *spyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *spyTransport) CloseIdleConnections() {
+	s.closed = true
+}
+
+func TestCloseIdleConnectionsClosesTransport(t *testing.T) {
+	spy := &spyTransport{}
+	c := &awsClient{
+		session: session.Must(session.NewSession(&aws.Config{
+			Region:      aws.String("us-east-1"),
+			Credentials: credentials.NewStaticCredentials("id", "secret", "token"),
+			HTTPClient:  &http.Client{Transport: spy},
+		})),
+	}
+	c.CloseIdleConnections()
+	if !spy.closed {
+		t.Error("expected CloseIdleConnections to be called")
+	}
+}
+
+func TestCloseIdleConnectionsNilSession(t *testing.T) {
+	c := &awsClient{}
+	c.CloseIdleConnections()
 }

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -434,3 +434,32 @@ func (mr *MockRegionCacheMockRecorder) GetCachedDescribeRegions(awsSession inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedDescribeRegions", reflect.TypeOf((*MockRegionCache)(nil).GetCachedDescribeRegions), awsSession)
 }
+
+// IsRegionValidated mocks base method.
+func (m *MockRegionCache) IsRegionValidated(awsSession *session.Session, region string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRegionValidated", awsSession, region)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsRegionValidated indicates an expected call of IsRegionValidated.
+func (mr *MockRegionCacheMockRecorder) IsRegionValidated(awsSession, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRegionValidated", reflect.TypeOf((*MockRegionCache)(nil).IsRegionValidated), awsSession, region)
+}
+
+// SetRegionValidated mocks base method.
+func (m *MockRegionCache) SetRegionValidated(awsSession *session.Session, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRegionValidated", awsSession, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRegionValidated indicates an expected call of SetRegionValidated.
+func (mr *MockRegionCacheMockRecorder) SetRegionValidated(awsSession, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRegionValidated", reflect.TypeOf((*MockRegionCache)(nil).SetRegionValidated), awsSession, region)
+}


### PR DESCRIPTION
## Summary

- Cache region validation results across reconciliations so that SDK-unknown regions (e.g., `mx-central-1`) validated via `DescribeRegions` are not re-validated on every `NewValidatedClient()` call — reduces redundant API calls
- Close the AWS session's idle HTTP connections after each reconciliation via `defer` in every actuator method, preventing unbounded accumulation of HTTP transports and TLS state that caused the memory leak
- The `Client` interface is unchanged — session cleanup uses type assertion on the unexported `awsClient` struct, so fakes/mocks are unaffected

This change is in response to https://redhat.atlassian.net/browse/OCPBUGS-66932 - but since we couldn't reproduce it, we decided to leave the issue as NO-JIRA

## Test Plan

- [x] `make unit` passes with race detector (4 suites)
- [x] `make vet` and `gofmt` clean
- [x] Unit test: region validation cache miss on first call
- [x] Unit test: region validation cache hit after validation
- [x] Unit test: region validation cache expiry after 30 minutes
- [x] Unit test: per-credential isolation (different AccessKeyID)
- [x] Unit test: `CloseClientSession` closes idle connections (spy transport)
- [x] Unit test: `CloseClientSession` safe on nil and fake clients
- [x] Mock regenerated with `make generate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region validation is cached per credential with expiration to reduce repeated validation and speed checks.
  * Clients can close idle HTTP connections to free network resources.

* **Bug Fixes**
  * Machine operation scopes are reliably cleaned up after create/update/delete to ensure resources are released.

* **Tests**
  * Added tests for cache miss/hit, expiry, per-credential isolation, and session-close behaviors (including nil/no-op cases).

* **Tests (mocks)**
  * Test mocks updated to support new region-validation operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->