### PR TITLE
[release-4.19] NO-ISSUE: Add pprof endpoint to machine-controller-manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,8 +14,11 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strings"
 	"time"
@@ -53,6 +56,42 @@ var (
 	renewDealine  = 110 * time.Second
 	retryPeriod   = 20 * time.Second
 )
+
+type pprofServer struct {
+	Addr     string
+	CertFile string
+	KeyFile  string
+}
+
+func (s *pprofServer) Start(ctx context.Context) error {
+	srv := &http.Server{
+		Addr:    s.Addr,
+		Handler: http.DefaultServeMux,
+	}
+	klog.Infof("Starting pprof server on %s", s.Addr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServeTLS(s.CertFile, s.KeyFile); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("pprof server failed: %w", err)
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return srv.Shutdown(shutdownCtx)
+}
+
+func (s *pprofServer) NeedLeaderElection() bool {
+	return false
+}
 
 func main() {
 	printVersion := flag.Bool(
@@ -95,6 +134,12 @@ func main() {
 		"health-addr",
 		":9440",
 		"The address for health checking.",
+	)
+
+	pprofAddr := flag.String(
+		"pprof-bind-address",
+		":6060",
+		"The address for serving pprof profiling endpoints over TLS.",
 	)
 
 	// Sets up feature gates
@@ -224,6 +269,14 @@ func main() {
 
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		klog.Fatal(err)
+	}
+
+	if err := mgr.Add(&pprofServer{
+		Addr:     *pprofAddr,
+		CertFile: "/etc/machine-api-operator/tls/tls.crt",
+		KeyFile:  "/etc/machine-api-operator/tls/tls.key",
+	}); err != nil {
+		klog.Fatalf("Error adding pprof server: %v", err)
 	}
 
 	// Start the Cmd

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -43,8 +43,13 @@ func generateSelfSignedCert(dir string) (certFile, keyFile string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	certOut.Close()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		certOut.Close()
+		return "", "", err
+	}
+	if err := certOut.Close(); err != nil {
+		return "", "", err
+	}
 
 	keyDER, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
@@ -54,8 +59,13 @@ func generateSelfSignedCert(dir string) (certFile, keyFile string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-	keyOut.Close()
+	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		keyOut.Close()
+		return "", "", err
+	}
+	if err := keyOut.Close(); err != nil {
+		return "", "", err
+	}
 
 	return certFile, keyFile, nil
 }

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func generateSelfSignedCert(dir string) (certFile, keyFile string, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return "", "", err
+	}
+
+	certFile = filepath.Join(dir, "tls.crt")
+	keyFile = filepath.Join(dir, "tls.key")
+
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return "", "", err
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certOut.Close()
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return "", "", err
+	}
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		return "", "", err
+	}
+	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyOut.Close()
+
+	return certFile, keyFile, nil
+}
+
+func TestPprofServerResponds(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile, err := generateSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("failed to generate test cert: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := &pprofServer{
+		Addr:     addr,
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start(ctx)
+	}()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	var resp *http.Response
+	for i := 0; i < 20; i++ {
+		resp, err = client.Get(fmt.Sprintf("https://%s/debug/pprof/", addr))
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("pprof server did not respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("server returned error on shutdown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("server did not shut down within 10 seconds")
+	}
+}
+
+func TestPprofServerGracefulShutdown(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile, err := generateSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("failed to generate test cert: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := &pprofServer{
+		Addr:     addr,
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start(ctx)
+	}()
+
+	// Wait for the server to be ready
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	for i := 0; i < 20; i++ {
+		resp, getErr := client.Get(fmt.Sprintf("https://%s/debug/pprof/", addr))
+		if getErr == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("server returned error on shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down within 5 seconds")
+	}
+}
+
+func TestPprofServerNeedLeaderElection(t *testing.T) {
+	srv := &pprofServer{}
+	if srv.NeedLeaderElection() {
+		t.Error("pprofServer.NeedLeaderElection() returned true, expected false")
+	}
+}


### PR DESCRIPTION
Cherry-pick of #189 to release-4.19.

## Summary

- Serve net/http/pprof handlers over TLS on a dedicated port (default `:6060`) so heap, goroutine, and allocs profiles are available via `oc port-forward` without rebuilding
- The server runs on all replicas regardless of leader election
- New `--pprof-bind-address` CLI flag to configure the endpoint binding

## Test Plan

- [x] `make unit` passes with race detector
- [x] `make vet` and `gofmt` clean
- [x] Unit test: TLS startup and endpoint responsiveness
- [x] Unit test: graceful shutdown behavior