### PR TITLE
OCPBUGS-47508: Add max-concurrent-reconciles flag to machine actuator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -110,6 +110,12 @@ func main() {
 		"The address for serving pprof profiling endpoints (requires --enable-pprof).",
 	)
 
+	maxConcurrentReconciles := flag.Int(
+		"max-concurrent-reconciles",
+		1,
+		"Maximum number of concurrent reconciles per controller instance.",
+	)
+
 	// Sets up feature gates (version from build time, default 4 for unknown)
 	// Default should be changed to 5 once we branch for 5
 	majorVersion := version.Version.Major
@@ -216,7 +222,9 @@ func main() {
 		RegionCache:         describeRegionsCache,
 	})
 
-	if err := machine.AddWithActuator(mgr, machineActuator, defaultMutableGate); err != nil {
+	if err := machine.AddWithActuatorOpts(mgr, machineActuator, controller.Options{
+		MaxConcurrentReconciles: *maxConcurrentReconciles,
+	}, defaultMutableGate); err != nil {
 		klog.Fatalf("Error adding actuator: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
Add `--max-concurrent-reconciles` (default `1`) and pass it through `machine.AddWithActuatorOpts` into controller-runtime `MaxConcurrentReconciles`, matching Azure and GCP.

## What was checked
Thread-safety / concurrency skim of MAPA paths that matter at `MaxConcurrentReconciles=10`:

- controller-runtime still serializes reconciles per Machine key; concurrency only parallelizes across different Machines
- `regionCache` is `sync.RWMutex`-guarded; shared-credentials file construction is mutexed
- AWS clients/sessions are built per reconcile (no long-lived shared EC2 client across Machines)
- Create path looks up existing instances before `RunInstances` (idempotency guard); same Machine cannot double-create under key serialization
- MachineSet instance-type cache is separate and also mutexed; drain controller is unaffected (still default options)
- No unlocked process-global mutable maps found on the machine actuator path

Residual ops risk is normal EC2 API pressure/throttling under large waves (same class of risk Azure/GCP already accept at concurrency 10), not memory unsafety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to configure the maximum number of concurrent reconciliation operations.
  * Improved control over controller processing concurrency during manager startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->